### PR TITLE
feat: add --fix, --list, --verify, --info, --here, --parents for v1.2.0

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Project Overview
 
-`claude-move-project` is a bash utility that moves Claude Code projects while preserving all session history and settings. It handles three interconnected data stores:
+`claude-move-project` is a bash utility that moves, fixes, lists, verifies, and manages Claude Code projects while preserving all session history and settings. It handles three interconnected data stores:
 
 1. **Project folder** - The actual project directory with code and `.claude/` settings
 2. **History folder** - `~/.claude/projects/[encoded-path]/` containing session JSONL files
@@ -25,6 +25,9 @@ Test locally by running with `--dry-run` flag:
 - Implements atomic rollback via EXIT trap if any step fails
 - Handles macOS vs Linux `sed -i` differences
 - Path resolution works for both existing and non-existing destination paths
+- Must be compatible with bash 3.2 (macOS default) — no associative arrays
+- Encoded path format is lossy (can't decode back) — use history.jsonl as source of truth
+- `_list_has` uses `grep -qFx --` (note `--` to handle values starting with `-`)
 
 ## Migration Sequence
 

--- a/README.md
+++ b/README.md
@@ -8,9 +8,15 @@ A bash utility that moves Claude Code projects while preserving all session hist
 ## Features
 
 - **Move** project folders to new locations
+- **Move here** (`--here`) — move a project into the current directory
+- **Fix** (`--fix`) — repair broken references after manual `mv`
+- **List** (`--list`) — show all Claude projects with status
+- **Verify** (`--verify`) — health check for project references
+- **Info** (`--info`) — detailed info about a single project
 - **Remove** projects and all associated session data (`--remove`)
 - **Pack** projects into portable `.claudepack` archives (`--pack`)
 - **Unpack** archives with automatic path rewriting (`--unpack`)
+- Auto-create parent directories with `-p`/`--parents`
 - Automatically migrates session history from `~/.claude/projects/`
 - Updates all path references in `~/.claude/history.jsonl`
 - Atomic rollback if any step fails
@@ -36,6 +42,26 @@ sudo ln -s "$(pwd)/claude-move-project" /usr/local/bin/claude-move-project
 # Move a project
 claude-move-project <source> <destination> [options]
 
+# Move project into current directory
+claude-move-project --here <source>
+
+# Move to deeply nested path (auto-create parents)
+claude-move-project <source> <destination> -p
+
+# Fix broken references after manual mv
+claude-move-project --fix
+claude-move-project --fix <new-path>
+claude-move-project --fix --from <old-path> --to <new-path>
+
+# List all Claude projects
+claude-move-project --list [--json]
+
+# Health check
+claude-move-project --verify
+
+# Project info
+claude-move-project --info <project-path>
+
 # Remove a project and all session data
 claude-move-project --remove <project-path>
 
@@ -55,28 +81,38 @@ claude-move-project ./my-project ~/new-location --dry-run
 # Move a project (specifying full destination path)
 claude-move-project ./my-project ~/new-location/my-project
 
+# Move into current directory
+cd ~/new-location && claude-move-project --here ~/old/my-project
+
+# Move to nested path that doesn't exist yet
+claude-move-project ./my-project ~/deep/nested/new/path -p
+
 # Move into an existing directory (mv-like behavior)
-# If ~/projects/ exists, this moves to ~/projects/my-project
 claude-move-project ./my-project ~/projects
 
 # Move without confirmation prompt
 claude-move-project ./my-project ~/new-location --force
 
-# Move with verbose output
-claude-move-project ./my-project ~/new-location --verbose
+# Fix after manual mv (most common scenario)
+mv ~/old/my-project ~/new/my-project
+claude-move-project --fix ~/new/my-project       # auto-detect old path
+claude-move-project --fix --from ~/old/my-project --to ~/new/my-project
 
-# Move a project with special characters in name
-claude-move-project "./project [v1.0]" "./project [v2.0]"
+# List all projects and their status
+claude-move-project --list
+claude-move-project --list --json
+
+# Check health of all project references
+claude-move-project --verify
+
+# Get detailed info about a project
+claude-move-project --info ./my-project
 
 # Remove project and all session data
 claude-move-project --remove ./my-project
-claude-move-project --remove ./my-project --dry-run
 
-# Pack project for transfer
+# Pack/unpack project for transfer
 claude-move-project --pack ./my-project
-claude-move-project --pack ./my-project ~/backup.claudepack
-
-# Unpack to new location
 claude-move-project --unpack backup.claudepack ~/new-location
 ```
 
@@ -99,11 +135,20 @@ claude-move-project ./my-app ~/projects
 
 | Option | Description |
 |--------|-------------|
+| `--here` | Move project into current directory |
+| `--fix` | Repair broken references after manual mv |
+| `--list` | List all Claude projects with status |
+| `--verify` | Health check for project references |
+| `--info` | Show detailed info about a project |
 | `--remove` | Delete project and all Claude session data |
 | `--pack` | Archive project into .claudepack file |
 | `--unpack` | Restore archive to destination |
+| `-p, --parents` | Create parent directories as needed |
 | `-n, --dry-run` | Preview changes without executing |
 | `-f, --force` | Skip confirmation prompt |
+| `--json` | Output in JSON format (for --list) |
+| `--from <path>` | Original path (for --fix) |
+| `--to <path>` | New path (for --fix) |
 | `--no-backup` | Skip backup of history.jsonl |
 | `-v, --verbose` | Show detailed output |
 | `-h, --help` | Show help message |
@@ -127,6 +172,21 @@ This script handles all three, ensuring your session history follows your projec
 4. Update path references in `history.jsonl`
 
 If any step fails, all changes are automatically rolled back.
+
+### Fix Operation
+
+The most common scenario: you already moved a folder with `mv` and Claude sessions broke.
+
+```bash
+# Auto-detect: scans for broken entries, tries to match by project name
+claude-move-project --fix
+
+# Point to the new location: auto-finds the broken old entry
+claude-move-project --fix ~/new/location/my-project
+
+# Explicit: specify both old and new paths
+claude-move-project --fix --from ~/old/path --to ~/new/path
+```
 
 ### Archive Format (.claudepack)
 
@@ -163,14 +223,20 @@ The test suite covers:
 - Dry-run mode
 - Error conditions (missing source, existing dest)
 - Backup/rollback functionality
+- `--list` (basic, JSON, empty, broken projects)
+- `--here` mode
+- `--parents` flag
+- `--verify` (healthy and broken states)
+- `--info` output
+- `--fix` (explicit paths, auto-detect, nothing broken)
 
 ## Supported Platforms
 
 | Platform | Status |
 |----------|--------|
-| macOS | ✅ Fully supported |
-| Linux | ✅ Supported |
-| Windows | ⚠️ Via WSL or Git Bash |
+| macOS | Fully supported |
+| Linux | Supported |
+| Windows | Via WSL or Git Bash |
 
 ### Windows Users
 

--- a/claude-move-project
+++ b/claude-move-project
@@ -12,12 +12,12 @@
 
 set -euo pipefail
 
-VERSION="1.1.0"
+VERSION="1.2.0"
 CLAUDE_DIR="$HOME/.claude"
 PROJECTS_DIR="$CLAUDE_DIR/projects"
 HISTORY_FILE="$CLAUDE_DIR/history.jsonl"
 
-# Operation mode: move (default), remove, pack, unpack
+# Operation mode: move (default), remove, pack, unpack, list, fix, verify, info
 OPERATION="move"
 
 # Colors for output
@@ -46,6 +46,11 @@ DRY_RUN=false
 FORCE=false
 BACKUP=true
 VERBOSE=false
+PARENTS=false
+JSON_OUTPUT=false
+HERE_MODE=false
+FIX_FROM=""
+FIX_TO=""
 
 log_info() {
     echo -e "${BLUE}[INFO]${NC} $1"
@@ -66,19 +71,30 @@ log_error() {
 show_help() {
     cat << EOF
 claude-move-project v$VERSION
-Move, remove, pack, or unpack Claude Code projects with session history.
+Move, remove, pack, unpack, list, fix, verify, or inspect Claude Code projects.
 
 Usage:
   claude-move-project [OPTIONS] <source> <destination>
+  claude-move-project --here [OPTIONS] <source>
   claude-move-project --remove [OPTIONS] <project-path>
   claude-move-project --pack [OPTIONS] <project-path> [archive-path]
   claude-move-project --unpack [OPTIONS] <archive-path> <destination>
+  claude-move-project --list [--json]
+  claude-move-project --fix [project-path]
+  claude-move-project --fix --from <old-path> --to <new-path>
+  claude-move-project --verify
+  claude-move-project --info <project-path>
 
 Operations:
   (default)           Move project to new location
+  --here              Move project into current directory
   --remove            Delete project and all Claude session data
   --pack              Archive project into portable .claudepack file
   --unpack            Restore archive to destination with path rewriting
+  --list              List all Claude projects with status
+  --fix               Repair broken project references after manual mv
+  --verify            Check integrity of all project references
+  --info              Show detailed info about a project
 
 Arguments:
   source/project-path  Path to the project (can be relative or absolute)
@@ -88,7 +104,11 @@ Arguments:
 Options:
   -n, --dry-run       Preview changes without executing
   -f, --force         Skip confirmation prompt
+  -p, --parents       Create parent directories as needed
   --no-backup         Skip backup of history.jsonl
+  --json              Output in JSON format (for --list)
+  --from <path>       Original path (for --fix)
+  --to <path>         New path (for --fix)
   -v, --verbose       Show detailed output
   -h, --help          Show this help message
   --version           Show version
@@ -96,19 +116,26 @@ Options:
 Examples:
   # Move project
   claude-move-project ./my-project ~/new-location/my-project
-  claude-move-project /Users/me/old-path /Users/me/new-path --dry-run
+  claude-move-project --here ~/old-location/my-project
+  claude-move-project ./project ~/deep/nested/path -p
 
   # Remove project and all session data
   claude-move-project --remove ./my-project
-  claude-move-project --remove ./my-project --dry-run
 
-  # Pack project for transfer
+  # Pack/unpack project
   claude-move-project --pack ./my-project
-  claude-move-project --pack ./my-project ~/archives/my-project.claudepack
+  claude-move-project --unpack backup.claudepack ~/projects/my-project
 
-  # Unpack archive to new location
-  claude-move-project --unpack my-project.claudepack ~/projects/my-project
-  claude-move-project --unpack backup.claudepack ./restored --dry-run
+  # List, inspect, and maintain
+  claude-move-project --list
+  claude-move-project --list --json
+  claude-move-project --info ./my-project
+  claude-move-project --verify
+
+  # Fix broken references after manual mv
+  claude-move-project --fix                              # auto-detect
+  claude-move-project --fix /new/location/my-project     # find old path
+  claude-move-project --fix --from /old/path --to /new/path
 
 What gets migrated:
   - Project folder (moved/copied/deleted based on operation)
@@ -252,8 +279,34 @@ parse_args() {
                 FORCE=true
                 shift
                 ;;
+            -p|--parents)
+                PARENTS=true
+                shift
+                ;;
             --no-backup)
                 BACKUP=false
+                shift
+                ;;
+            --json)
+                JSON_OUTPUT=true
+                shift
+                ;;
+            --from)
+                shift
+                if [[ $# -eq 0 ]]; then
+                    log_error "--from requires a path argument"
+                    exit 1
+                fi
+                FIX_FROM="$1"
+                shift
+                ;;
+            --to)
+                shift
+                if [[ $# -eq 0 ]]; then
+                    log_error "--to requires a path argument"
+                    exit 1
+                fi
+                FIX_TO="$1"
                 shift
                 ;;
             -v|--verbose)
@@ -292,6 +345,42 @@ parse_args() {
                 OPERATION="unpack"
                 shift
                 ;;
+            --list)
+                if [[ "$OPERATION" != "move" ]]; then
+                    log_error "Cannot combine --list with --$OPERATION"
+                    exit 1
+                fi
+                OPERATION="list"
+                shift
+                ;;
+            --fix|--repair)
+                if [[ "$OPERATION" != "move" ]]; then
+                    log_error "Cannot combine --fix with --$OPERATION"
+                    exit 1
+                fi
+                OPERATION="fix"
+                shift
+                ;;
+            --verify|--health)
+                if [[ "$OPERATION" != "move" ]]; then
+                    log_error "Cannot combine --verify with --$OPERATION"
+                    exit 1
+                fi
+                OPERATION="verify"
+                shift
+                ;;
+            --info)
+                if [[ "$OPERATION" != "move" ]]; then
+                    log_error "Cannot combine --info with --$OPERATION"
+                    exit 1
+                fi
+                OPERATION="info"
+                shift
+                ;;
+            --here)
+                HERE_MODE=true
+                shift
+                ;;
             -*)
                 log_error "Unknown option: $1"
                 echo "Use --help for usage information"
@@ -312,6 +401,24 @@ parse_args() {
                 ;;
         esac
     done
+
+    # Handle --here mode: convert to a move operation
+    if [[ "$HERE_MODE" == true ]]; then
+        if [[ "$OPERATION" != "move" ]]; then
+            log_error "Cannot combine --here with --$OPERATION"
+            exit 1
+        fi
+        if [[ "$arg1_set" == false ]]; then
+            log_error "Source path required with --here"
+            echo "Usage: claude-move-project --here <source>"
+            exit 1
+        fi
+        SOURCE="$ARG1"
+        local source_basename
+        source_basename=$(basename "$ARG1")
+        DESTINATION="./$source_basename"
+        return
+    fi
 
     # Validate argument count based on operation
     case "$OPERATION" in
@@ -367,6 +474,26 @@ parse_args() {
             ARCHIVE_PATH="$ARG1"
             DESTINATION="$ARG2"
             ;;
+        list)
+            # No arguments required
+            ;;
+        fix)
+            # Optional: single path arg or --from/--to
+            if [[ "$arg1_set" == true ]]; then
+                FIX_TO="$ARG1"
+            fi
+            ;;
+        verify)
+            # No arguments required
+            ;;
+        info)
+            if [[ "$arg1_set" == false ]]; then
+                log_error "Project path required"
+                echo "Usage: claude-move-project --info <project-path>"
+                exit 1
+            fi
+            SOURCE="$ARG1"
+            ;;
     esac
 }
 
@@ -414,9 +541,19 @@ validate_move() {
     local dest_parent
     dest_parent=$(dirname "$DESTINATION")
     if [[ ! -d "$dest_parent" ]]; then
-        log_error "Destination parent directory does not exist: $dest_parent"
-        echo "Create it first with: mkdir -p \"$dest_parent\""
-        exit 1
+        if [[ "$PARENTS" == true ]]; then
+            if [[ "$DRY_RUN" == false ]]; then
+                mkdir -p "$dest_parent"
+                log_verbose "Created parent directories: $dest_parent"
+            else
+                log_info "Would create parent directories: $dest_parent"
+            fi
+        else
+            log_error "Destination parent directory does not exist: $dest_parent"
+            echo "Create it first with: mkdir -p \"$dest_parent\""
+            echo "Or use -p/--parents to create automatically"
+            exit 1
+        fi
     fi
     DEST_ABS=$(get_absolute_path "$DESTINATION")
     log_verbose "Resolved destination path: $DEST_ABS"
@@ -524,9 +661,19 @@ validate_unpack() {
     local dest_parent
     dest_parent=$(dirname "$DESTINATION")
     if [[ ! -d "$dest_parent" ]]; then
-        log_error "Destination parent directory does not exist: $dest_parent"
-        echo "Create it first with: mkdir -p \"$dest_parent\""
-        exit 1
+        if [[ "$PARENTS" == true ]]; then
+            if [[ "$DRY_RUN" == false ]]; then
+                mkdir -p "$dest_parent"
+                log_verbose "Created parent directories: $dest_parent"
+            else
+                log_info "Would create parent directories: $dest_parent"
+            fi
+        else
+            log_error "Destination parent directory does not exist: $dest_parent"
+            echo "Create it first with: mkdir -p \"$dest_parent\""
+            echo "Or use -p/--parents to create automatically"
+            exit 1
+        fi
     fi
     DEST_ABS=$(get_absolute_path "$DESTINATION")
     log_verbose "Resolved destination path: $DEST_ABS"
@@ -557,6 +704,38 @@ validate_unpack() {
     fi
 }
 
+# Validate inputs for info operation
+validate_info() {
+    validate_source_project
+}
+
+# Validate inputs for fix operation
+validate_fix() {
+    # --fix with --from/--to: validate both exist/don't exist
+    if [[ -n "$FIX_FROM" && -n "$FIX_TO" ]]; then
+        # --from path should NOT exist (project was moved away)
+        if [[ -d "$FIX_FROM" ]]; then
+            log_warn "Source path still exists: $FIX_FROM"
+            log_warn "If the project was copied (not moved), this is expected"
+        fi
+        # --to path SHOULD exist (project is now here)
+        if [[ ! -d "$FIX_TO" ]]; then
+            log_error "Destination path does not exist: $FIX_TO"
+            exit 1
+        fi
+        FIX_FROM=$(get_absolute_path "$FIX_FROM")
+        FIX_TO=$(get_absolute_path "$FIX_TO")
+    elif [[ -n "$FIX_TO" ]]; then
+        # Single path: project's new location, auto-detect old
+        if [[ ! -d "$FIX_TO" ]]; then
+            log_error "Path does not exist: $FIX_TO"
+            exit 1
+        fi
+        FIX_TO=$(get_absolute_path "$FIX_TO")
+    fi
+    # No args: full auto-detect mode — validated during execute
+}
+
 # Dispatch to appropriate validation function
 validate() {
     case "$OPERATION" in
@@ -564,6 +743,10 @@ validate() {
         remove) validate_remove ;;
         pack)   validate_pack ;;
         unpack) validate_unpack ;;
+        list)   ;; # No validation needed
+        fix)    validate_fix ;;
+        verify) ;; # No validation needed
+        info)   validate_info ;;
     esac
 }
 
@@ -777,6 +960,7 @@ show_preview() {
         remove) show_preview_remove ;;
         pack)   show_preview_pack ;;
         unpack) show_preview_unpack ;;
+        list|verify|info|fix) ;; # These operations handle their own output
     esac
 }
 
@@ -803,6 +987,14 @@ confirm() {
         unpack)
             prompt="Unpack archive to destination? [y/N] "
             action_name="Unpack"
+            ;;
+        list|verify|info)
+            # Read-only operations don't need confirmation
+            return 0
+            ;;
+        fix)
+            # Fix confirmation is handled inside execute_fix
+            return 0
             ;;
     esac
 
@@ -1097,8 +1289,723 @@ execute_unpack() {
     echo "  cd $DEST_ABS && claude --continue"
 }
 
+# Get last modified time of a file in human-readable format
+get_last_modified() {
+    local path="$1"
+    if [[ "$(uname)" == "Darwin" ]]; then
+        stat -f "%Sm" -t "%Y-%m-%d %H:%M" "$path" 2>/dev/null || echo "unknown"
+    else
+        stat -c "%y" "$path" 2>/dev/null | cut -d'.' -f1 || echo "unknown"
+    fi
+}
+
+# Get last modified time as epoch seconds (for sorting)
+get_last_modified_epoch() {
+    local path="$1"
+    if [[ "$(uname)" == "Darwin" ]]; then
+        stat -f "%m" "$path" 2>/dev/null || echo "0"
+    else
+        stat -c "%Y" "$path" 2>/dev/null || echo "0"
+    fi
+}
+
+# Count session files for a given encoded path
+count_sessions() {
+    local encoded="$1"
+    if [[ -d "$PROJECTS_DIR/$encoded" ]]; then
+        find "$PROJECTS_DIR/$encoded" -name "*.jsonl" 2>/dev/null | wc -l | tr -d ' '
+    else
+        echo "0"
+    fi
+}
+
+# Check if a value exists in a newline-separated string
+# Usage: if _list_has "$seen_list" "$value"; then ...
+_list_has() {
+    local list="$1"
+    local val="$2"
+    echo "$list" | grep -qFx -- "$val" 2>/dev/null
+}
+
+# Extract unique project paths from history.jsonl
+_extract_history_projects() {
+    if [[ -f "$HISTORY_FILE" ]]; then
+        grep -o '"project":"[^"]*"' "$HISTORY_FILE" 2>/dev/null | \
+            sed 's/"project":"//;s/"$//' | sort -u || true
+    fi
+}
+
+# Execute list operation
+execute_list() {
+    # Collect all known project paths from history.jsonl and session folders
+    local projects=""
+    local seen=""
+
+    # Source 1: Parse history.jsonl for project paths
+    local hist_projects
+    hist_projects=$(_extract_history_projects)
+    if [[ -n "$hist_projects" ]]; then
+        while IFS= read -r proj_path; do
+            if [[ -n "$proj_path" ]] && ! _list_has "$seen" "$proj_path"; then
+                projects="${projects}${projects:+$'\n'}${proj_path}"
+                seen="${seen}${seen:+$'\n'}${proj_path}"
+            fi
+        done <<< "$hist_projects"
+    fi
+
+    # Source 2: Scan session folders for any not matching a history entry
+    # Note: We can't reliably decode encoded paths (hyphens in names collide),
+    # so we check if any known project encodes to each session folder
+    local known_encoded=""
+    if [[ -n "$seen" ]]; then
+        while IFS= read -r kp; do
+            [[ -z "$kp" ]] && continue
+            known_encoded="${known_encoded}${known_encoded:+$'\n'}${kp//\//-}"
+        done <<< "$seen"
+    fi
+
+    if [[ -d "$PROJECTS_DIR" ]]; then
+        for session_dir in "$PROJECTS_DIR"/*/; do
+            [[ -d "$session_dir" ]] || continue
+            local encoded
+            encoded=$(basename "$session_dir")
+            if ! _list_has "$known_encoded" "$encoded"; then
+                local label="(orphaned session: $encoded)"
+                projects="${projects}${projects:+$'\n'}${label}"
+            fi
+        done
+    fi
+
+    if [[ -z "$projects" ]]; then
+        if [[ "$JSON_OUTPUT" == true ]]; then
+            echo "[]"
+        else
+            echo "No Claude projects found."
+        fi
+        return 0
+    fi
+
+    local project_count=0
+    while IFS= read -r _p; do
+        [[ -n "$_p" ]] && ((project_count++))
+    done <<< "$projects"
+
+    if [[ "$JSON_OUTPUT" == true ]]; then
+        # JSON output
+        echo "["
+        local first=true
+        while IFS= read -r proj_path; do
+            [[ -z "$proj_path" ]] && continue
+            local encoded="${proj_path//\//-}"
+            local sessions
+            sessions=$(count_sessions "$encoded")
+            local size="0"
+            local session_size="0"
+            local exists=false
+            local last_activity="unknown"
+
+            if [[ -d "$proj_path" ]]; then
+                exists=true
+                size=$(du -sk "$proj_path" 2>/dev/null | cut -f1)
+            fi
+            if [[ -d "$PROJECTS_DIR/$encoded" ]]; then
+                session_size=$(du -sk "$PROJECTS_DIR/$encoded" 2>/dev/null | cut -f1)
+                # Get last activity from newest session file
+                local newest
+                newest=$(find "$PROJECTS_DIR/$encoded" -name "*.jsonl" -type f 2>/dev/null | head -1)
+                if [[ -n "$newest" ]]; then
+                    last_activity=$(get_last_modified "$newest")
+                fi
+            fi
+
+            if [[ "$first" == true ]]; then
+                first=false
+            else
+                echo ","
+            fi
+            printf '  {"path":"%s","exists":%s,"sessions":%s,"project_size_kb":%s,"session_size_kb":%s,"last_activity":"%s"}' \
+                "$proj_path" "$exists" "$sessions" "$size" "$session_size" "$last_activity"
+        done <<< "$projects"
+        echo ""
+        echo "]"
+    else
+        # Human-readable output
+        echo ""
+        echo "Claude Code Projects"
+        echo "===================="
+        echo ""
+
+        local healthy=0
+        local broken=0
+
+        while IFS= read -r proj_path; do
+            [[ -z "$proj_path" ]] && continue
+            local encoded="${proj_path//\//-}"
+            local sessions
+            sessions=$(count_sessions "$encoded")
+            local status_icon status_label
+
+            if [[ -d "$proj_path" ]]; then
+                status_icon="${GREEN}●${NC}"
+                status_label=""
+                ((healthy++)) || true
+            else
+                status_icon="${RED}●${NC}"
+                status_label=" ${RED}(missing)${NC}"
+                ((broken++)) || true
+            fi
+
+            local size_info=""
+            if [[ -d "$PROJECTS_DIR/$encoded" ]]; then
+                local session_size
+                session_size=$(get_folder_size "$PROJECTS_DIR/$encoded")
+                size_info=" | sessions: $session_size"
+            fi
+
+            echo -e "  $status_icon $proj_path$status_label"
+            echo -e "    Sessions: $sessions$size_info"
+        done <<< "$projects"
+
+        echo ""
+        echo "Total: $project_count projects ($healthy healthy, $broken broken)"
+        if [[ $broken -gt 0 ]]; then
+            echo -e "${YELLOW}Run 'claude-move-project --fix' to repair broken references${NC}"
+        fi
+    fi
+}
+
+# Execute verify operation
+execute_verify() {
+    echo ""
+    echo "Claude Code Project Health Check"
+    echo "================================="
+    echo ""
+
+    local issues=0
+    local unique_projects=""
+
+    # Check 1: History entries pointing to non-existent paths
+    log_info "Checking history.jsonl entries..."
+    local broken_history=""
+    local broken_count=0
+    if [[ -f "$HISTORY_FILE" ]]; then
+        unique_projects=$(_extract_history_projects)
+        if [[ -n "$unique_projects" ]]; then
+            while IFS= read -r proj_path; do
+                [[ -z "$proj_path" ]] && continue
+                if [[ ! -d "$proj_path" ]]; then
+                    broken_history="${broken_history}${broken_history:+$'\n'}${proj_path}"
+                    ((broken_count++)) || true
+                fi
+            done <<< "$unique_projects"
+        fi
+    fi
+
+    if [[ $broken_count -gt 0 ]]; then
+        echo -e "  ${RED}Found $broken_count broken history reference(s):${NC}"
+        while IFS= read -r bp; do
+            [[ -z "$bp" ]] && continue
+            echo -e "    ${RED}✗${NC} $bp"
+        done <<< "$broken_history"
+        issues=$((issues + broken_count))
+    else
+        echo -e "  ${GREEN}✓${NC} All history references are valid"
+    fi
+    echo ""
+
+    # Check 2: Orphaned session folders (no matching project on disk)
+    # Build a list of all encoded paths that map to known history projects
+    log_info "Checking session folders..."
+    local known_encoded=""
+    if [[ -n "$unique_projects" ]]; then
+        while IFS= read -r pp; do
+            [[ -z "$pp" ]] && continue
+            known_encoded="${known_encoded}${known_encoded:+$'\n'}${pp//\//-}"
+        done <<< "$unique_projects"
+    fi
+
+    local orphaned_sessions=""
+    local orphaned_count=0
+    if [[ -d "$PROJECTS_DIR" ]]; then
+        for session_dir in "$PROJECTS_DIR"/*/; do
+            [[ -d "$session_dir" ]] || continue
+            local encoded
+            encoded=$(basename "$session_dir")
+            # A session folder is orphaned if no project in history encodes to it
+            # AND no project directory on disk encodes to it
+            local has_match=false
+            if _list_has "$known_encoded" "$encoded"; then
+                has_match=true
+            fi
+            if [[ "$has_match" == false ]]; then
+                orphaned_sessions="${orphaned_sessions}${orphaned_sessions:+$'\n'}${encoded}"
+                ((orphaned_count++)) || true
+            fi
+        done
+    fi
+
+    if [[ $orphaned_count -gt 0 ]]; then
+        echo -e "  ${YELLOW}Found $orphaned_count orphaned session folder(s):${NC}"
+        while IFS= read -r os; do
+            [[ -z "$os" ]] && continue
+            local size
+            size=$(get_folder_size "$PROJECTS_DIR/$os")
+            echo -e "    ${YELLOW}?${NC} $PROJECTS_DIR/$os ($size)"
+        done <<< "$orphaned_sessions"
+        issues=$((issues + orphaned_count))
+    else
+        echo -e "  ${GREEN}✓${NC} No orphaned session folders"
+    fi
+    echo ""
+
+    # Check 3: Projects with history but no session folder
+    log_info "Checking for missing session folders..."
+    local missing_sessions=0
+    if [[ -f "$HISTORY_FILE" ]]; then
+        local unique_hist
+        unique_hist=$(_extract_history_projects)
+        if [[ -n "$unique_hist" ]]; then
+            while IFS= read -r proj_path; do
+                [[ -z "$proj_path" ]] && continue
+                local encoded="${proj_path//\//-}"
+                if [[ -d "$proj_path" && ! -d "$PROJECTS_DIR/$encoded" ]]; then
+                    if [[ $missing_sessions -eq 0 ]]; then
+                        echo -e "  ${YELLOW}Projects with history entries but no session folder:${NC}"
+                    fi
+                    echo -e "    ${YELLOW}?${NC} $proj_path"
+                    ((missing_sessions++)) || true
+                fi
+            done <<< "$unique_hist"
+        fi
+    fi
+
+    if [[ $missing_sessions -eq 0 ]]; then
+        echo -e "  ${GREEN}✓${NC} All projects have matching session folders"
+    fi
+    issues=$((issues + missing_sessions))
+    echo ""
+
+    # Summary
+    if [[ $issues -eq 0 ]]; then
+        echo -e "${GREEN}All checks passed! No issues found.${NC}"
+    else
+        echo -e "${YELLOW}Found $issues issue(s).${NC}"
+        echo "Run 'claude-move-project --fix' to attempt automatic repair."
+    fi
+}
+
+# Execute info operation
+execute_info() {
+    local encoded="${SOURCE_ABS//\//-}"
+
+    echo ""
+    echo "Claude Code Project Info"
+    echo "========================"
+    echo ""
+
+    # Project path and status
+    echo "Path: $SOURCE_ABS"
+    echo "Encoded: $encoded"
+    if [[ -d "$SOURCE_ABS" ]]; then
+        echo -e "Status: ${GREEN}exists${NC}"
+        local project_size
+        project_size=$(get_folder_size "$SOURCE_ABS")
+        echo "Project size: $project_size"
+    else
+        echo -e "Status: ${RED}missing${NC}"
+    fi
+    echo ""
+
+    # .claude/ settings
+    if [[ -d "$SOURCE_ABS/.claude" ]]; then
+        echo -e "Settings: ${GREEN}.claude/ directory found${NC}"
+        if [[ -f "$SOURCE_ABS/.claude/settings.json" ]]; then
+            echo "  - settings.json"
+        fi
+        if [[ -f "$SOURCE_ABS/CLAUDE.md" ]]; then
+            echo "  - CLAUDE.md"
+        fi
+    else
+        echo "Settings: no .claude/ directory"
+    fi
+    echo ""
+
+    # Session folder
+    echo "Session folder: $PROJECTS_DIR/$encoded/"
+    if [[ -d "$PROJECTS_DIR/$encoded" ]]; then
+        local session_count session_size
+        session_count=$(count_sessions "$encoded")
+        session_size=$(get_folder_size "$PROJECTS_DIR/$encoded")
+        echo -e "  Status: ${GREEN}exists${NC}"
+        echo "  Sessions: $session_count JSONL file(s)"
+        echo "  Size: $session_size"
+
+        # Show newest and oldest session
+        local newest oldest
+        newest=$(find "$PROJECTS_DIR/$encoded" -name "*.jsonl" -type f -exec stat -f "%m %N" {} \; 2>/dev/null | sort -rn | head -1 | cut -d' ' -f2-)
+        oldest=$(find "$PROJECTS_DIR/$encoded" -name "*.jsonl" -type f -exec stat -f "%m %N" {} \; 2>/dev/null | sort -n | head -1 | cut -d' ' -f2-)
+
+        if [[ -n "$newest" ]]; then
+            echo "  Newest session: $(get_last_modified "$newest")"
+        fi
+        if [[ -n "$oldest" && "$oldest" != "$newest" ]]; then
+            echo "  Oldest session: $(get_last_modified "$oldest")"
+        fi
+    else
+        echo -e "  Status: ${YELLOW}not found${NC}"
+    fi
+    echo ""
+
+    # History entries
+    if [[ -f "$HISTORY_FILE" ]]; then
+        local entry_count
+        entry_count=$(grep -c -F -- "\"project\":\"$SOURCE_ABS\"" "$HISTORY_FILE" 2>/dev/null) || entry_count=0
+        echo "History entries: $entry_count"
+    else
+        echo "History entries: (history file not found)"
+    fi
+}
+
+# Execute fix operation
+execute_fix() {
+    echo ""
+    echo "Claude Code Project Fix"
+    echo "======================="
+    echo ""
+
+    if [[ -n "$FIX_FROM" && -n "$FIX_TO" ]]; then
+        # Explicit mode: --fix --from /old --to /new
+        execute_fix_explicit "$FIX_FROM" "$FIX_TO"
+    elif [[ -n "$FIX_TO" ]]; then
+        # Single path mode: --fix /new/path — auto-detect old path
+        execute_fix_detect_old "$FIX_TO"
+    else
+        # Full auto-detect mode
+        execute_fix_auto
+    fi
+}
+
+# Fix with explicit --from and --to paths
+execute_fix_explicit() {
+    local old_path="$1"
+    local new_path="$2"
+    local old_encoded="${old_path//\//-}"
+    local new_encoded="${new_path//\//-}"
+
+    log_info "Fixing: $old_path → $new_path"
+    echo ""
+
+    local changes=0
+
+    # Check and rename session folder
+    if [[ -d "$PROJECTS_DIR/$old_encoded" ]]; then
+        echo "Session folder: $PROJECTS_DIR/$old_encoded/"
+        echo "  → $PROJECTS_DIR/$new_encoded/"
+        changes=1
+    elif [[ -d "$PROJECTS_DIR/$new_encoded" ]]; then
+        log_info "Session folder already at new location"
+    else
+        log_warn "No session folder found for either path"
+    fi
+
+    # Check history entries
+    local entry_count=0
+    if [[ -f "$HISTORY_FILE" ]]; then
+        entry_count=$(grep -c -F -- "\"project\":\"$old_path\"" "$HISTORY_FILE" 2>/dev/null) || entry_count=0
+        if [[ $entry_count -gt 0 ]]; then
+            echo "History entries to update: $entry_count"
+            changes=1
+        fi
+    fi
+
+    if [[ $changes -eq 0 ]]; then
+        log_info "Nothing to fix — references already correct"
+        return 0
+    fi
+
+    echo ""
+
+    if [[ "$DRY_RUN" == true ]]; then
+        echo "Run without --dry-run to apply fix."
+        return 0
+    fi
+
+    # Confirm
+    if [[ "$FORCE" != true ]]; then
+        read -p "Apply fix? [y/N] " -n 1 -r
+        echo ""
+        if [[ ! $REPLY =~ ^[Yy]$ ]]; then
+            log_info "Fix cancelled"
+            return 0
+        fi
+    fi
+
+    # Backup
+    if [[ "$BACKUP" == true && -f "$HISTORY_FILE" ]]; then
+        BACKUP_FILE="$HISTORY_FILE.backup.$(date +%Y%m%d-%H%M%S)"
+        cp "$HISTORY_FILE" "$BACKUP_FILE"
+        log_success "Created backup: $BACKUP_FILE"
+    fi
+
+    # Rename session folder
+    if [[ -d "$PROJECTS_DIR/$old_encoded" ]]; then
+        if [[ -d "$PROJECTS_DIR/$new_encoded" ]]; then
+            log_warn "New session folder already exists, skipping rename"
+        else
+            mv "$PROJECTS_DIR/$old_encoded" "$PROJECTS_DIR/$new_encoded"
+            log_success "Renamed session folder"
+        fi
+    fi
+
+    # Update history.jsonl
+    if [[ -f "$HISTORY_FILE" && $entry_count -gt 0 ]]; then
+        local old_escaped new_escaped
+        old_escaped=$(escape_for_sed "$old_path")
+        new_escaped=$(escape_for_sed "$new_path")
+
+        if [[ "$(uname)" == "Darwin" ]]; then
+            sed -i '' "s|\"project\":\"$old_escaped\"|\"project\":\"$new_escaped\"|g" "$HISTORY_FILE"
+        else
+            sed -i "s|\"project\":\"$old_escaped\"|\"project\":\"$new_escaped\"|g" "$HISTORY_FILE"
+        fi
+        log_success "Updated $entry_count history entries"
+    fi
+
+    echo ""
+    log_success "Fix complete!"
+    echo ""
+    echo "Resume your session with:"
+    echo "  cd $new_path && claude --continue"
+}
+
+# Fix with auto-detected old path from a new path
+execute_fix_detect_old() {
+    local new_path="$1"
+    local new_name
+    new_name=$(basename "$new_path")
+
+    log_info "Looking for broken references that match: $new_name"
+    echo ""
+
+    # Find broken history entries
+    local candidates=""
+    local candidate_count=0
+    local seen=""
+
+    if [[ -f "$HISTORY_FILE" ]]; then
+        local unique_projects
+        unique_projects=$(_extract_history_projects)
+        if [[ -n "$unique_projects" ]]; then
+            while IFS= read -r proj_path; do
+                [[ -z "$proj_path" ]] && continue
+                if [[ ! -d "$proj_path" ]]; then
+                    local old_name
+                    old_name=$(basename "$proj_path")
+                    if [[ "$old_name" == "$new_name" ]] && ! _list_has "$seen" "$proj_path"; then
+                        candidates="${candidates}${candidates:+$'\n'}${proj_path}"
+                        seen="${seen}${seen:+$'\n'}${proj_path}"
+                        ((candidate_count++)) || true
+                    fi
+                fi
+            done <<< "$unique_projects"
+        fi
+    fi
+
+    if [[ $candidate_count -eq 0 ]]; then
+        log_warn "No broken references found matching '$new_name'"
+        echo "Try: claude-move-project --fix --from <old-path> --to $new_path"
+        return 1
+    elif [[ $candidate_count -eq 1 ]]; then
+        local first_candidate
+        first_candidate=$(echo "$candidates" | head -1)
+        log_info "Found match: $first_candidate"
+        execute_fix_explicit "$first_candidate" "$new_path"
+    else
+        echo "Multiple broken references found:"
+        local i=1
+        while IFS= read -r c; do
+            [[ -z "$c" ]] && continue
+            echo "  $i) $c"
+            ((i++)) || true
+        done <<< "$candidates"
+        echo ""
+
+        if [[ "$FORCE" == true ]]; then
+            local first_candidate
+            first_candidate=$(echo "$candidates" | head -1)
+            log_info "Using first match (--force)"
+            execute_fix_explicit "$first_candidate" "$new_path"
+        else
+            read -p "Select which to fix (1-$candidate_count): " -r
+            local idx=$((REPLY))
+            local selected
+            selected=$(echo "$candidates" | sed -n "${idx}p")
+            if [[ -n "$selected" ]]; then
+                execute_fix_explicit "$selected" "$new_path"
+            else
+                log_error "Invalid selection"
+                return 1
+            fi
+        fi
+    fi
+}
+
+# Full auto-detect fix mode
+execute_fix_auto() {
+    log_info "Scanning for broken project references..."
+    echo ""
+
+    # Find all broken entries
+    local broken_paths=""
+    local broken_count=0
+    local seen=""
+
+    if [[ -f "$HISTORY_FILE" ]]; then
+        local unique_projects
+        unique_projects=$(_extract_history_projects)
+        if [[ -n "$unique_projects" ]]; then
+            while IFS= read -r proj_path; do
+                [[ -z "$proj_path" ]] && continue
+                if [[ ! -d "$proj_path" ]] && ! _list_has "$seen" "$proj_path"; then
+                    seen="${seen}${seen:+$'\n'}${proj_path}"
+                    broken_paths="${broken_paths}${broken_paths:+$'\n'}${proj_path}"
+                    ((broken_count++)) || true
+                fi
+            done <<< "$unique_projects"
+        fi
+    fi
+
+    # Also check orphaned session folders (ones not matching any history entry)
+    # Build known encoded paths from history
+    local known_encoded=""
+    if [[ -n "$unique_projects" ]]; then
+        while IFS= read -r kp; do
+            [[ -z "$kp" ]] && continue
+            known_encoded="${known_encoded}${known_encoded:+$'\n'}${kp//\//-}"
+        done <<< "$unique_projects"
+    fi
+
+    if [[ -d "$PROJECTS_DIR" ]]; then
+        for session_dir in "$PROJECTS_DIR"/*/; do
+            [[ -d "$session_dir" ]] || continue
+            local encoded
+            encoded=$(basename "$session_dir")
+            # Only flag as orphaned if no history entry maps to this folder
+            if ! _list_has "$known_encoded" "$encoded" && ! _list_has "$seen" "(orphaned:$encoded)"; then
+                seen="${seen}${seen:+$'\n'}(orphaned:$encoded)"
+                # We can't reliably decode the path, so just note it
+                broken_paths="${broken_paths}${broken_paths:+$'\n'}(orphaned session: $PROJECTS_DIR/$encoded)"
+                ((broken_count++)) || true
+            fi
+        done
+    fi
+
+    if [[ $broken_count -eq 0 ]]; then
+        log_success "No broken references found. Everything looks good!"
+        return 0
+    fi
+
+    echo -e "${YELLOW}Found $broken_count broken reference(s):${NC}"
+    echo ""
+
+    local fixed=0
+    while IFS= read -r bp; do
+        [[ -z "$bp" ]] && continue
+        local bp_name
+        bp_name=$(basename "$bp")
+        echo -e "  ${RED}✗${NC} $bp"
+
+        # Try to find the project by name on disk using common locations
+        local matches=""
+        local match_seen=""
+
+        # Search for directories with same name in common parent locations
+        local bp_parent
+        bp_parent=$(dirname "$bp")
+        local bp_grandparent
+        bp_grandparent=$(dirname "$bp_parent")
+
+        # Look in parent directory and grandparent directory
+        for search_dir in "$bp_parent" "$bp_grandparent" "$HOME" "$HOME/Documents" "$HOME/Projects" "$HOME/projects" "$HOME/code" "$HOME/dev" "$HOME/workspace"; do
+            if [[ -d "$search_dir" ]]; then
+                while IFS= read -r match; do
+                    [[ -d "$match" ]] || continue
+                    local match_abs
+                    match_abs=$(cd "$match" && pwd)
+                    # Don't match the broken path itself, deduplicate
+                    if [[ "$match_abs" != "$bp" ]] && ! _list_has "$match_seen" "$match_abs"; then
+                        matches="${matches}${matches:+$'\n'}${match_abs}"
+                        match_seen="${match_seen}${match_seen:+$'\n'}${match_abs}"
+                    fi
+                done < <(find "$search_dir" -maxdepth 3 -type d -name "$bp_name" 2>/dev/null)
+            fi
+        done
+
+        local match_count=0
+        if [[ -n "$matches" ]]; then
+            match_count=$(echo "$matches" | wc -l | tr -d ' ')
+        fi
+
+        if [[ $match_count -eq 0 ]]; then
+            echo "    No matching directory found. Use:"
+            echo "    claude-move-project --fix --from \"$bp\" --to <new-path>"
+        elif [[ $match_count -eq 1 ]]; then
+            local single_match
+            single_match=$(echo "$matches" | head -1)
+            echo "    Possible match: $single_match"
+            if [[ "$DRY_RUN" == true ]]; then
+                echo "    Would fix: $bp → $single_match"
+            elif [[ "$FORCE" == true ]]; then
+                execute_fix_explicit "$bp" "$single_match"
+                ((fixed++)) || true
+            else
+                read -p "    Fix $bp → $single_match? [y/N] " -n 1 -r
+                echo ""
+                if [[ $REPLY =~ ^[Yy]$ ]]; then
+                    execute_fix_explicit "$bp" "$single_match"
+                    ((fixed++)) || true
+                fi
+            fi
+        else
+            echo "    Multiple possible matches:"
+            local i=1
+            while IFS= read -r m; do
+                [[ -z "$m" ]] && continue
+                echo "      $i) $m"
+                ((i++)) || true
+            done <<< "$matches"
+            if [[ "$DRY_RUN" != true && "$FORCE" != true ]]; then
+                read -p "    Select match (1-$match_count, or Enter to skip): " -r
+                if [[ -n "$REPLY" ]]; then
+                    local selected
+                    selected=$(echo "$matches" | sed -n "${REPLY}p")
+                    if [[ -n "$selected" ]]; then
+                        execute_fix_explicit "$bp" "$selected"
+                        ((fixed++)) || true
+                    fi
+                fi
+            fi
+        fi
+        echo ""
+    done <<< "$broken_paths"
+
+    if [[ "$DRY_RUN" == true ]]; then
+        echo "Run without --dry-run to apply fixes."
+    else
+        echo "Fixed $fixed of $broken_count broken reference(s)."
+    fi
+}
+
 # Dispatch to appropriate execute function
 execute() {
+    # Read-only operations bypass dry-run gate
+    case "$OPERATION" in
+        list)   execute_list; return ;;
+        verify) execute_verify; return ;;
+        info)   execute_info; return ;;
+        fix)    execute_fix; return ;;
+    esac
+
     if [[ "$DRY_RUN" == true ]]; then
         local action_desc
         case "$OPERATION" in

--- a/test.sh
+++ b/test.sh
@@ -1,0 +1,775 @@
+#!/usr/bin/env bash
+#
+# test.sh - Test suite for claude-move-project
+#
+# Usage: ./test.sh [test_name]
+#   Run all tests: ./test.sh
+#   Run single test: ./test.sh test_basic_move
+#
+
+set -euo pipefail
+
+# Colors
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[0;33m'
+BLUE='\033[0;34m'
+NC='\033[0m'
+
+# Test directory setup
+TEST_DIR=""
+MOCK_CLAUDE_DIR=""
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SCRIPT="$SCRIPT_DIR/claude-move-project"
+
+# Test counters
+TESTS_PASSED=0
+TESTS_FAILED=0
+TESTS_SKIPPED=0
+
+log_test() {
+    echo -e "${BLUE}[TEST]${NC} $1"
+}
+
+log_pass() {
+    echo -e "${GREEN}[PASS]${NC} $1"
+    ((TESTS_PASSED++))
+}
+
+log_fail() {
+    echo -e "${RED}[FAIL]${NC} $1"
+    ((TESTS_FAILED++))
+}
+
+log_skip() {
+    echo -e "${YELLOW}[SKIP]${NC} $1"
+    ((TESTS_SKIPPED++))
+}
+
+# Setup test environment
+setup_test_env() {
+    TEST_DIR=$(mktemp -d)
+    MOCK_CLAUDE_DIR="$TEST_DIR/.claude"
+    mkdir -p "$MOCK_CLAUDE_DIR/projects"
+    touch "$MOCK_CLAUDE_DIR/history.jsonl"
+
+    # Export for the script to use
+    export HOME="$TEST_DIR"
+}
+
+# Cleanup test environment
+cleanup_test_env() {
+    # Return to original directory first (in case test changed cwd)
+    cd "$SCRIPT_DIR" 2>/dev/null || true
+    if [[ -n "$TEST_DIR" && -d "$TEST_DIR" ]]; then
+        rm -rf "$TEST_DIR"
+    fi
+}
+
+# Create a mock project with history
+create_mock_project() {
+    local project_path="$1"
+    local project_name="${2:-test-project}"
+
+    mkdir -p "$project_path"
+    mkdir -p "$project_path/.claude"
+    echo "# Test Project" > "$project_path/README.md"
+    echo "test content" > "$project_path/.claude/settings.json"
+
+    # Create encoded history folder
+    local abs_path
+    abs_path=$(cd "$project_path" && pwd)
+    local encoded="${abs_path//\//-}"
+
+    mkdir -p "$MOCK_CLAUDE_DIR/projects/$encoded"
+    echo '{"type":"session","data":"test"}' > "$MOCK_CLAUDE_DIR/projects/$encoded/session1.jsonl"
+
+    # Add entry to history.jsonl
+    echo "{\"project\":\"$abs_path\",\"session\":\"session1\"}" >> "$MOCK_CLAUDE_DIR/history.jsonl"
+}
+
+# Assert file exists
+assert_exists() {
+    local path="$1"
+    local msg="${2:-File should exist: $path}"
+    if [[ -e "$path" ]]; then
+        return 0
+    else
+        echo "  Assertion failed: $msg"
+        return 1
+    fi
+}
+
+# Assert file does not exist
+assert_not_exists() {
+    local path="$1"
+    local msg="${2:-File should not exist: $path}"
+    if [[ ! -e "$path" ]]; then
+        return 0
+    else
+        echo "  Assertion failed: $msg"
+        return 1
+    fi
+}
+
+# Assert directory exists
+assert_dir_exists() {
+    local path="$1"
+    local msg="${2:-Directory should exist: $path}"
+    if [[ -d "$path" ]]; then
+        return 0
+    else
+        echo "  Assertion failed: $msg"
+        return 1
+    fi
+}
+
+# Assert file contains string
+assert_contains() {
+    local file="$1"
+    local pattern="$2"
+    local msg="${3:-File should contain: $pattern}"
+    if grep -qF -- "$pattern" "$file" 2>/dev/null; then
+        return 0
+    else
+        echo "  Assertion failed: $msg"
+        return 1
+    fi
+}
+
+# Assert file does not contain string
+assert_not_contains() {
+    local file="$1"
+    local pattern="$2"
+    local msg="${3:-File should not contain: $pattern}"
+    if ! grep -qF -- "$pattern" "$file" 2>/dev/null; then
+        return 0
+    else
+        echo "  Assertion failed: $msg"
+        return 1
+    fi
+}
+
+# Assert command fails
+assert_fails() {
+    local msg="$1"
+    shift
+    if ! "$@" >/dev/null 2>&1; then
+        return 0
+    else
+        echo "  Assertion failed: $msg"
+        return 1
+    fi
+}
+
+# Run a single test with setup/teardown
+run_test() {
+    local test_name="$1"
+    log_test "Running: $test_name"
+
+    setup_test_env
+
+    local result=0
+    if $test_name; then
+        log_pass "$test_name"
+    else
+        log_fail "$test_name"
+        result=1
+    fi
+
+    cleanup_test_env
+    return $result
+}
+
+# ============================================================================
+# TEST CASES
+# ============================================================================
+
+test_basic_move() {
+    # Create source project
+    create_mock_project "$TEST_DIR/source-project"
+    local source_abs="$TEST_DIR/source-project"
+    local dest_abs="$TEST_DIR/dest-project"
+
+    # Run migration
+    "$SCRIPT" "$source_abs" "$dest_abs" -f
+
+    # Verify project moved
+    assert_not_exists "$source_abs" "Source should be gone" || return 1
+    assert_dir_exists "$dest_abs" "Destination should exist" || return 1
+    assert_exists "$dest_abs/README.md" "README should be moved" || return 1
+    assert_exists "$dest_abs/.claude/settings.json" "Settings should be moved" || return 1
+
+    # Verify history folder renamed
+    local old_encoded="${source_abs//\//-}"
+    local new_encoded="${dest_abs//\//-}"
+    assert_not_exists "$MOCK_CLAUDE_DIR/projects/$old_encoded" "Old history folder should be gone" || return 1
+    assert_dir_exists "$MOCK_CLAUDE_DIR/projects/$new_encoded" "New history folder should exist" || return 1
+
+    # Verify history.jsonl updated
+    assert_not_contains "$MOCK_CLAUDE_DIR/history.jsonl" "$source_abs" "Old path should not be in history" || return 1
+    assert_contains "$MOCK_CLAUDE_DIR/history.jsonl" "$dest_abs" "New path should be in history" || return 1
+}
+
+test_relative_source() {
+    # Create source project
+    mkdir -p "$TEST_DIR/workspace"
+    create_mock_project "$TEST_DIR/workspace/my-app"
+
+    # Run from workspace with relative source
+    (
+        cd "$TEST_DIR/workspace"
+        "$SCRIPT" "./my-app" "$TEST_DIR/moved-app" -f
+    )
+
+    assert_not_exists "$TEST_DIR/workspace/my-app" "Source should be gone" || return 1
+    assert_dir_exists "$TEST_DIR/moved-app" "Destination should exist" || return 1
+}
+
+test_relative_dest() {
+    # Create source project
+    mkdir -p "$TEST_DIR/workspace"
+    create_mock_project "$TEST_DIR/workspace/project"
+    mkdir -p "$TEST_DIR/workspace/subdir"
+
+    # Run with relative destination
+    (
+        cd "$TEST_DIR/workspace"
+        "$SCRIPT" "$TEST_DIR/workspace/project" "./subdir/renamed" -f
+    )
+
+    assert_not_exists "$TEST_DIR/workspace/project" "Source should be gone" || return 1
+    assert_dir_exists "$TEST_DIR/workspace/subdir/renamed" "Destination should exist" || return 1
+}
+
+test_dest_is_directory() {
+    # Create source project
+    create_mock_project "$TEST_DIR/my-project"
+
+    # Create destination directory (should move INTO it)
+    mkdir -p "$TEST_DIR/target-dir"
+
+    "$SCRIPT" "$TEST_DIR/my-project" "$TEST_DIR/target-dir" -f
+
+    # Should be moved INTO target-dir, not replace it
+    assert_not_exists "$TEST_DIR/my-project" "Source should be gone" || return 1
+    assert_dir_exists "$TEST_DIR/target-dir/my-project" "Should be moved into target dir" || return 1
+    assert_exists "$TEST_DIR/target-dir/my-project/README.md" "Files should be in new location" || return 1
+}
+
+test_special_chars_brackets() {
+    # Create project with brackets in name
+    create_mock_project "$TEST_DIR/project [test]"
+    local source_abs="$TEST_DIR/project [test]"
+    local dest_abs="$TEST_DIR/renamed [test]"
+
+    "$SCRIPT" "$source_abs" "$dest_abs" -f
+
+    assert_not_exists "$source_abs" "Source should be gone" || return 1
+    assert_dir_exists "$dest_abs" "Destination should exist" || return 1
+
+    # Verify history was updated correctly
+    assert_contains "$MOCK_CLAUDE_DIR/history.jsonl" "$dest_abs" "New path should be in history" || return 1
+}
+
+test_special_chars_spaces() {
+    # Create project with spaces in name
+    create_mock_project "$TEST_DIR/my project name"
+    local source_abs="$TEST_DIR/my project name"
+    local dest_abs="$TEST_DIR/new project name"
+
+    "$SCRIPT" "$source_abs" "$dest_abs" -f
+
+    assert_not_exists "$source_abs" "Source should be gone" || return 1
+    assert_dir_exists "$dest_abs" "Destination should exist" || return 1
+    assert_contains "$MOCK_CLAUDE_DIR/history.jsonl" "$dest_abs" "New path should be in history" || return 1
+}
+
+test_special_chars_dots() {
+    # Create project with dots in name
+    create_mock_project "$TEST_DIR/my.project.v1.0"
+    local source_abs="$TEST_DIR/my.project.v1.0"
+    local dest_abs="$TEST_DIR/my.project.v2.0"
+
+    "$SCRIPT" "$source_abs" "$dest_abs" -f
+
+    assert_not_exists "$source_abs" "Source should be gone" || return 1
+    assert_dir_exists "$dest_abs" "Destination should exist" || return 1
+}
+
+test_symlink_source() {
+    # Create actual project
+    create_mock_project "$TEST_DIR/real-project"
+
+    # Create symlink to it
+    ln -s "$TEST_DIR/real-project" "$TEST_DIR/link-project"
+
+    # Move the symlink (should warn but proceed)
+    local output
+    output=$("$SCRIPT" "$TEST_DIR/link-project" "$TEST_DIR/moved-link" -f 2>&1)
+
+    if ! echo "$output" | grep -q "symlink"; then
+        echo "  Should warn about symlink"
+        echo "  Output was: $output"
+        return 1
+    fi
+
+    # The symlink should have been moved, not the target
+    assert_not_exists "$TEST_DIR/link-project" "Symlink source should be gone" || return 1
+    assert_dir_exists "$TEST_DIR/real-project" "Original project should still exist" || return 1
+}
+
+test_dry_run() {
+    # Create source project
+    create_mock_project "$TEST_DIR/dry-project"
+    local source_abs="$TEST_DIR/dry-project"
+    local dest_abs="$TEST_DIR/dry-dest"
+
+    # Run with --dry-run
+    "$SCRIPT" "$source_abs" "$dest_abs" --dry-run
+
+    # Nothing should have changed
+    assert_dir_exists "$source_abs" "Source should still exist" || return 1
+    assert_not_exists "$dest_abs" "Destination should not exist" || return 1
+
+    # History should be unchanged
+    assert_contains "$MOCK_CLAUDE_DIR/history.jsonl" "$source_abs" "History should still have old path" || return 1
+}
+
+test_nonexistent_source() {
+    # Try to move nonexistent source
+    assert_fails "Should fail with nonexistent source" \
+        "$SCRIPT" "$TEST_DIR/does-not-exist" "$TEST_DIR/dest" -f
+}
+
+test_dest_exists() {
+    # Create source and destination
+    create_mock_project "$TEST_DIR/source"
+    mkdir -p "$TEST_DIR/dest-exists"
+    touch "$TEST_DIR/dest-exists/file.txt"
+
+    # Try to move to existing destination (not a directory case - exact path exists)
+    # First, move source into dest-exists (mv-like behavior)
+    "$SCRIPT" "$TEST_DIR/source" "$TEST_DIR/dest-exists" -f
+
+    # Should succeed by moving INTO the directory
+    assert_dir_exists "$TEST_DIR/dest-exists/source" "Should move into existing dir" || return 1
+}
+
+test_dest_file_exists() {
+    # Create source
+    create_mock_project "$TEST_DIR/source"
+
+    # Create a file (not directory) at destination path
+    touch "$TEST_DIR/dest-file"
+
+    # Should fail - destination exists but is a file
+    # Note: This might need to be handled differently depending on implementation
+    assert_fails "Should fail when destination is a file" \
+        "$SCRIPT" "$TEST_DIR/source" "$TEST_DIR/dest-file" -f
+}
+
+test_missing_parent() {
+    # Create source project
+    create_mock_project "$TEST_DIR/source"
+
+    # Try to move to location where parent doesn't exist
+    assert_fails "Should fail when parent doesn't exist" \
+        "$SCRIPT" "$TEST_DIR/source" "$TEST_DIR/nonexistent/subdir/dest" -f
+}
+
+test_no_history() {
+    # Create project without history
+    mkdir -p "$TEST_DIR/no-history-project"
+    echo "# Test" > "$TEST_DIR/no-history-project/README.md"
+
+    # Should still move the project folder (with warning)
+    local output
+    output=$("$SCRIPT" "$TEST_DIR/no-history-project" "$TEST_DIR/moved-no-history" -f 2>&1)
+
+    if ! echo "$output" | grep -q "No Claude history"; then
+        echo "  Should warn about missing history"
+        echo "  Output was: $output"
+        return 1
+    fi
+
+    assert_not_exists "$TEST_DIR/no-history-project" "Source should be gone" || return 1
+    assert_dir_exists "$TEST_DIR/moved-no-history" "Destination should exist" || return 1
+}
+
+test_verbose_output() {
+    # Create source project
+    create_mock_project "$TEST_DIR/verbose-test"
+
+    # Run with verbose flag
+    local output
+    output=$("$SCRIPT" "$TEST_DIR/verbose-test" "$TEST_DIR/verbose-dest" -f -v 2>&1)
+
+    # Check for verbose output
+    if echo "$output" | grep -q "\[VERBOSE\]"; then
+        return 0
+    else
+        echo "  Verbose output not found"
+        return 1
+    fi
+}
+
+test_backup_created() {
+    # Create source project
+    create_mock_project "$TEST_DIR/backup-test"
+
+    # Run migration
+    "$SCRIPT" "$TEST_DIR/backup-test" "$TEST_DIR/backup-dest" -f
+
+    # Check backup was created
+    local backup_count
+    backup_count=$(ls "$MOCK_CLAUDE_DIR"/history.jsonl.backup.* 2>/dev/null | wc -l | tr -d ' ')
+    if [[ "$backup_count" -ge 1 ]]; then
+        return 0
+    else
+        echo "  Backup file not found"
+        return 1
+    fi
+}
+
+test_no_backup_flag() {
+    # Create source project
+    create_mock_project "$TEST_DIR/no-backup-test"
+
+    # Run migration with --no-backup
+    "$SCRIPT" "$TEST_DIR/no-backup-test" "$TEST_DIR/no-backup-dest" -f --no-backup
+
+    # Check no backup was created
+    local backup_count
+    backup_count=$(ls "$MOCK_CLAUDE_DIR"/history.jsonl.backup.* 2>/dev/null | wc -l | tr -d ' ')
+    if [[ "$backup_count" -eq 0 ]]; then
+        return 0
+    else
+        echo "  Backup file should not exist"
+        return 1
+    fi
+}
+
+test_same_source_dest() {
+    # Create source project
+    create_mock_project "$TEST_DIR/same-project"
+
+    # Try to move to same location
+    assert_fails "Should fail when source and dest are same" \
+        "$SCRIPT" "$TEST_DIR/same-project" "$TEST_DIR/same-project" -f
+}
+
+# ============================================================================
+# NEW FEATURE TESTS (v1.2.0)
+# ============================================================================
+
+test_list_basic() {
+    # Create two projects
+    create_mock_project "$TEST_DIR/project-a"
+    create_mock_project "$TEST_DIR/project-b"
+
+    # Run --list
+    local output
+    output=$("$SCRIPT" --list 2>&1)
+
+    # Should show both projects
+    if echo "$output" | grep -q "project-a" && echo "$output" | grep -q "project-b"; then
+        return 0
+    else
+        echo "  Expected both projects in output"
+        echo "  Output: $output"
+        return 1
+    fi
+}
+
+test_list_json() {
+    # Create a project
+    create_mock_project "$TEST_DIR/json-project"
+
+    # Run --list --json
+    local output
+    output=$("$SCRIPT" --list --json 2>&1)
+
+    # Should be valid JSON-ish (starts with [)
+    if echo "$output" | grep -q '^\['; then
+        return 0
+    else
+        echo "  Expected JSON output starting with ["
+        echo "  Output: $output"
+        return 1
+    fi
+}
+
+test_list_empty() {
+    # No projects created — empty env
+    local output
+    output=$("$SCRIPT" --list 2>&1)
+
+    if echo "$output" | grep -q "No Claude projects found"; then
+        return 0
+    else
+        echo "  Expected 'No Claude projects found' message"
+        echo "  Output: $output"
+        return 1
+    fi
+}
+
+test_list_broken_project() {
+    # Create project then delete the folder (simulate manual rm)
+    create_mock_project "$TEST_DIR/broken-project"
+    local abs_path
+    abs_path=$(cd "$TEST_DIR/broken-project" && pwd)
+    rm -rf "$TEST_DIR/broken-project"
+
+    local output
+    output=$("$SCRIPT" --list 2>&1)
+
+    # Should show as broken/missing
+    if echo "$output" | grep -q "missing"; then
+        return 0
+    else
+        echo "  Expected 'missing' marker for broken project"
+        echo "  Output: $output"
+        return 1
+    fi
+}
+
+test_here_mode() {
+    # Create source project
+    create_mock_project "$TEST_DIR/source-for-here"
+    local source_abs="$TEST_DIR/source-for-here"
+
+    # Create target dir and run --here from it
+    mkdir -p "$TEST_DIR/target-dir"
+    (
+        cd "$TEST_DIR/target-dir"
+        "$SCRIPT" --here "$source_abs" -f
+    )
+
+    assert_not_exists "$source_abs" "Source should be gone" || return 1
+    assert_dir_exists "$TEST_DIR/target-dir/source-for-here" "Project should be in target dir" || return 1
+    assert_exists "$TEST_DIR/target-dir/source-for-here/README.md" "Files should be moved" || return 1
+}
+
+test_parents_flag() {
+    # Create source project
+    create_mock_project "$TEST_DIR/parents-source"
+    local source_abs="$TEST_DIR/parents-source"
+
+    # Move to deeply nested non-existent path with -p
+    "$SCRIPT" "$source_abs" "$TEST_DIR/deep/nested/new/location" -f -p
+
+    assert_not_exists "$source_abs" "Source should be gone" || return 1
+    assert_dir_exists "$TEST_DIR/deep/nested/new/location" "Nested destination should exist" || return 1
+    assert_exists "$TEST_DIR/deep/nested/new/location/README.md" "Files should be moved" || return 1
+}
+
+test_parents_flag_not_set() {
+    # Create source project
+    create_mock_project "$TEST_DIR/no-parents-source"
+
+    # Move to non-existent nested path WITHOUT -p should fail
+    assert_fails "Should fail without -p flag" \
+        "$SCRIPT" "$TEST_DIR/no-parents-source" "$TEST_DIR/nonexistent/deep/path" -f
+}
+
+test_verify_healthy() {
+    # Create a healthy project
+    create_mock_project "$TEST_DIR/healthy-project"
+
+    local output
+    output=$("$SCRIPT" --verify 2>&1)
+
+    if echo "$output" | grep -q "All checks passed"; then
+        return 0
+    else
+        echo "  Expected all checks to pass"
+        echo "  Output: $output"
+        return 1
+    fi
+}
+
+test_verify_broken() {
+    # Create project then delete it
+    create_mock_project "$TEST_DIR/verify-broken"
+    rm -rf "$TEST_DIR/verify-broken"
+
+    local output
+    output=$("$SCRIPT" --verify 2>&1)
+
+    if echo "$output" | grep -q "broken history reference"; then
+        return 0
+    else
+        echo "  Expected broken history reference"
+        echo "  Output: $output"
+        return 1
+    fi
+}
+
+test_info_basic() {
+    # Create a project
+    create_mock_project "$TEST_DIR/info-project"
+
+    local output
+    output=$("$SCRIPT" --info "$TEST_DIR/info-project" 2>&1)
+
+    # Should show path and session info
+    if echo "$output" | grep -q "info-project" && echo "$output" | grep -q "Sessions:"; then
+        return 0
+    else
+        echo "  Expected project info with sessions"
+        echo "  Output: $output"
+        return 1
+    fi
+}
+
+test_fix_explicit() {
+    # Create project, simulate manual mv
+    create_mock_project "$TEST_DIR/fix-before"
+    local old_abs
+    old_abs=$(cd "$TEST_DIR/fix-before" && pwd)
+
+    # Manual mv (breaking history)
+    mv "$TEST_DIR/fix-before" "$TEST_DIR/fix-after"
+
+    # Run fix with --from/--to
+    "$SCRIPT" --fix --from "$old_abs" --to "$TEST_DIR/fix-after" -f
+
+    # Verify history.jsonl was updated
+    local new_abs
+    new_abs=$(cd "$TEST_DIR/fix-after" && pwd)
+    assert_contains "$MOCK_CLAUDE_DIR/history.jsonl" "$new_abs" "History should point to new path" || return 1
+    assert_not_contains "$MOCK_CLAUDE_DIR/history.jsonl" "$old_abs" "History should not contain old path" || return 1
+
+    # Verify session folder was renamed
+    local old_encoded="${old_abs//\//-}"
+    local new_encoded="${new_abs//\//-}"
+    assert_not_exists "$MOCK_CLAUDE_DIR/projects/$old_encoded" "Old session folder should be gone" || return 1
+    assert_dir_exists "$MOCK_CLAUDE_DIR/projects/$new_encoded" "New session folder should exist" || return 1
+}
+
+test_fix_auto_detect() {
+    # Create project with a known name, simulate manual mv
+    create_mock_project "$TEST_DIR/auto-project"
+    local old_abs
+    old_abs=$(cd "$TEST_DIR/auto-project" && pwd)
+
+    # Manual mv to a different location
+    mkdir -p "$TEST_DIR/new-home"
+    mv "$TEST_DIR/auto-project" "$TEST_DIR/new-home/auto-project"
+
+    local new_abs
+    new_abs=$(cd "$TEST_DIR/new-home/auto-project" && pwd)
+
+    # Run fix with just the new path — should auto-detect old
+    "$SCRIPT" --fix "$new_abs" -f
+
+    # Verify history was updated
+    assert_contains "$MOCK_CLAUDE_DIR/history.jsonl" "$new_abs" "History should point to new path" || return 1
+    assert_not_contains "$MOCK_CLAUDE_DIR/history.jsonl" "$old_abs" "History should not contain old path" || return 1
+}
+
+test_fix_nothing_broken() {
+    # Create healthy project
+    create_mock_project "$TEST_DIR/all-good"
+
+    local output
+    output=$("$SCRIPT" --fix -f 2>&1)
+
+    if echo "$output" | grep -q "No broken references found"; then
+        return 0
+    else
+        echo "  Expected 'No broken references found'"
+        echo "  Output: $output"
+        return 1
+    fi
+}
+
+# ============================================================================
+# MAIN
+# ============================================================================
+
+main() {
+    echo ""
+    echo "Claude Move Project Test Suite"
+    echo "==============================="
+    echo ""
+
+    # Check script exists
+    if [[ ! -x "$SCRIPT" ]]; then
+        echo "Error: Script not found or not executable: $SCRIPT"
+        exit 1
+    fi
+
+    # List of all tests
+    local all_tests=(
+        test_basic_move
+        test_relative_source
+        test_relative_dest
+        test_dest_is_directory
+        test_special_chars_brackets
+        test_special_chars_spaces
+        test_special_chars_dots
+        test_symlink_source
+        test_dry_run
+        test_nonexistent_source
+        test_dest_exists
+        test_dest_file_exists
+        test_missing_parent
+        test_no_history
+        test_verbose_output
+        test_backup_created
+        test_no_backup_flag
+        test_same_source_dest
+        # v1.2.0 tests
+        test_list_basic
+        test_list_json
+        test_list_empty
+        test_list_broken_project
+        test_here_mode
+        test_parents_flag
+        test_parents_flag_not_set
+        test_verify_healthy
+        test_verify_broken
+        test_info_basic
+        test_fix_explicit
+        test_fix_auto_detect
+        test_fix_nothing_broken
+    )
+
+    # Run specific test or all tests
+    if [[ $# -ge 1 ]]; then
+        # Run specific test
+        local test_name="$1"
+        if declare -f "$test_name" > /dev/null; then
+            run_test "$test_name"
+        else
+            echo "Error: Unknown test: $test_name"
+            echo "Available tests:"
+            for t in "${all_tests[@]}"; do
+                echo "  $t"
+            done
+            exit 1
+        fi
+    else
+        # Run all tests
+        for test in "${all_tests[@]}"; do
+            run_test "$test" || true
+        done
+    fi
+
+    # Summary
+    echo ""
+    echo "==============================="
+    echo "Results:"
+    echo -e "  ${GREEN}Passed:${NC}  $TESTS_PASSED"
+    echo -e "  ${RED}Failed:${NC}  $TESTS_FAILED"
+    echo -e "  ${YELLOW}Skipped:${NC} $TESTS_SKIPPED"
+    echo ""
+
+    if [[ $TESTS_FAILED -gt 0 ]]; then
+        exit 1
+    fi
+}
+
+main "$@"


### PR DESCRIPTION
## Summary

- **`--fix`**: Repair broken project references after manual `mv`. Supports auto-detect, single-path, and explicit `--from`/`--to` modes — the most requested missing feature
- **`--list [--json]`**: Show all Claude projects with health status (healthy/missing), session count, and size
- **`--verify`**: Health check that finds broken history refs, orphaned session folders, and missing session data
- **`--info`**: Detailed info about a single project (size, session count, dates, encoded path)
- **`--here`**: Move project into current directory — shortcut for the most common move workflow
- **`-p/--parents`**: Auto-create parent directories for move/unpack operations (like `mkdir -p`)
- All features are **bash 3.2 compatible** (macOS default) — no associative arrays
- **13 new tests** added (31 total, all passing)

## Test plan

- [x] All 31 tests pass (`bash test.sh`)
- [x] All 18 original tests still pass (no regressions)
- [x] `--list` tested: basic, JSON output, empty state, broken project display
- [x] `--here` tested: moves project into cwd correctly
- [x] `-p` tested: creates nested parent dirs, fails without flag
- [x] `--verify` tested: healthy and broken project states
- [x] `--info` tested: shows project details
- [x] `--fix` tested: explicit paths, auto-detect old path, nothing-broken case
- [ ] Manual test on Linux

🤖 Generated with [Claude Code](https://claude.com/claude-code)