### PR TITLE
feat: rename claude-move-project to clamp (v1.3.0)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Project Overview
 
-`claude-move-project` is a bash utility that moves, fixes, lists, verifies, and manages Claude Code projects while preserving all session history and settings. It handles three interconnected data stores:
+`clamp` (**CL**aude **A**I **M**ove **P**roject) is a bash utility that moves, fixes, lists, verifies, and manages Claude Code projects while preserving all session history and settings. It handles three interconnected data stores:
 
 1. **Project folder** - The actual project directory with code and `.claude/` settings
 2. **History folder** - `~/.claude/projects/[encoded-path]/` containing session JSONL files
@@ -16,7 +16,7 @@ The encoded path format converts `/path/to/dir` to `-path-to-dir`.
 
 Test locally by running with `--dry-run` flag:
 ```bash
-./claude-move-project ./test-project ~/new-location --dry-run
+./clamp ./test-project ~/new-location --dry-run
 ```
 
 ## Key Implementation Details

--- a/README.md
+++ b/README.md
@@ -1,4 +1,6 @@
-# claude-move-project
+# clamp
+
+**CL**aude **A**I **M**ove **P**roject
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 [![Platform: macOS | Linux](https://img.shields.io/badge/Platform-macOS%20%7C%20Linux-blue.svg)](https://github.com/wsagency/claude-move-project#supported-platforms)
@@ -7,113 +9,113 @@ A bash utility that moves Claude Code projects while preserving all session hist
 
 ## Features
 
-- **Move** project folders to new locations
-- **Move here** (`--here`) — move a project into the current directory
-- **Fix** (`--fix`) — repair broken references after manual `mv`
-- **List** (`--list`) — show all Claude projects with status
-- **Verify** (`--verify`) — health check for project references
-- **Info** (`--info`) — detailed info about a single project
-- **Remove** projects and all associated session data (`--remove`)
-- **Pack** projects into portable `.claudepack` archives (`--pack`)
-- **Unpack** archives with automatic path rewriting (`--unpack`)
-- Auto-create parent directories with `-p`/`--parents`
-- Automatically migrates session history from `~/.claude/projects/`
-- Updates all path references in `~/.claude/history.jsonl`
-- Atomic rollback if any step fails
-- Dry-run mode to preview changes before execution
+- 📦 **Move** project folders to new locations
+- 📂 **Move here** (`--here`) — move a project into the current directory
+- 🔧 **Fix** (`--fix`) — repair broken references after manual `mv`
+- 📋 **List** (`--list`) — show all Claude projects with status
+- ✅ **Verify** (`--verify`) — health check for project references
+- ℹ️ **Info** (`--info`) — detailed info about a single project
+- 🗑️ **Remove** projects and all associated session data (`--remove`)
+- 📤 **Pack** projects into portable `.claudepack` archives (`--pack`)
+- 📥 **Unpack** archives with automatic path rewriting (`--unpack`)
+- 🗂️ Auto-create parent directories with `-p`/`--parents`
+- 🔄 Automatically migrates session history from `~/.claude/projects/`
+- 📝 Updates all path references in `~/.claude/history.jsonl`
+- 🛡️ Atomic rollback if any step fails
+- 👀 Dry-run mode to preview changes before execution
 
 ## Installation
 
 ```bash
 git clone https://github.com/wsagency/claude-move-project.git
 cd claude-move-project
-chmod +x claude-move-project
+chmod +x clamp
 ```
 
 Optionally, add to your PATH:
 
 ```bash
-sudo ln -s "$(pwd)/claude-move-project" /usr/local/bin/claude-move-project
+sudo ln -s "$(pwd)/clamp" /usr/local/bin/clamp
 ```
 
 ## Usage
 
 ```bash
 # Move a project
-claude-move-project <source> <destination> [options]
+clamp <source> <destination> [options]
 
 # Move project into current directory
-claude-move-project --here <source>
+clamp --here <source>
 
 # Move to deeply nested path (auto-create parents)
-claude-move-project <source> <destination> -p
+clamp <source> <destination> -p
 
 # Fix broken references after manual mv
-claude-move-project --fix
-claude-move-project --fix <new-path>
-claude-move-project --fix --from <old-path> --to <new-path>
+clamp --fix
+clamp --fix <new-path>
+clamp --fix --from <old-path> --to <new-path>
 
 # List all Claude projects
-claude-move-project --list [--json]
+clamp --list [--json]
 
 # Health check
-claude-move-project --verify
+clamp --verify
 
 # Project info
-claude-move-project --info <project-path>
+clamp --info <project-path>
 
 # Remove a project and all session data
-claude-move-project --remove <project-path>
+clamp --remove <project-path>
 
 # Pack a project into a portable archive
-claude-move-project --pack <project-path> [archive-path]
+clamp --pack <project-path> [archive-path]
 
 # Unpack an archive to a new location
-claude-move-project --unpack <archive-path> <destination>
+clamp --unpack <archive-path> <destination>
 ```
 
 ### Examples
 
 ```bash
 # Preview what would happen (recommended first step)
-claude-move-project ./my-project ~/new-location --dry-run
+clamp ./my-project ~/new-location --dry-run
 
 # Move a project (specifying full destination path)
-claude-move-project ./my-project ~/new-location/my-project
+clamp ./my-project ~/new-location/my-project
 
 # Move into current directory
-cd ~/new-location && claude-move-project --here ~/old/my-project
+cd ~/new-location && clamp --here ~/old/my-project
 
 # Move to nested path that doesn't exist yet
-claude-move-project ./my-project ~/deep/nested/new/path -p
+clamp ./my-project ~/deep/nested/new/path -p
 
 # Move into an existing directory (mv-like behavior)
-claude-move-project ./my-project ~/projects
+clamp ./my-project ~/projects
 
 # Move without confirmation prompt
-claude-move-project ./my-project ~/new-location --force
+clamp ./my-project ~/new-location --force
 
 # Fix after manual mv (most common scenario)
 mv ~/old/my-project ~/new/my-project
-claude-move-project --fix ~/new/my-project       # auto-detect old path
-claude-move-project --fix --from ~/old/my-project --to ~/new/my-project
+clamp --fix ~/new/my-project       # auto-detect old path
+clamp --fix --from ~/old/my-project --to ~/new/my-project
 
 # List all projects and their status
-claude-move-project --list
-claude-move-project --list --json
+clamp --list
+clamp --list --json
 
 # Check health of all project references
-claude-move-project --verify
+clamp --verify
 
 # Get detailed info about a project
-claude-move-project --info ./my-project
+clamp --info ./my-project
 
 # Remove project and all session data
-claude-move-project --remove ./my-project
+clamp --remove ./my-project
 
 # Pack/unpack project for transfer
-claude-move-project --pack ./my-project
-claude-move-project --unpack backup.claudepack ~/new-location
+clamp --pack ./my-project
+clamp --unpack backup.claudepack ~/new-location
 ```
 
 ### Destination Behavior
@@ -125,10 +127,10 @@ The destination argument works like `mv`:
 
 ```bash
 # Destination doesn't exist - creates ~/new-location as the project
-claude-move-project ./my-app ~/new-location
+clamp ./my-app ~/new-location
 
 # ~/projects exists - moves to ~/projects/my-app
-claude-move-project ./my-app ~/projects
+clamp ./my-app ~/projects
 ```
 
 ### Options
@@ -154,7 +156,7 @@ claude-move-project ./my-app ~/projects
 | `-h, --help` | Show help message |
 | `--version` | Show version |
 
-## How It Works
+## 🔍 How It Works
 
 Claude Code stores project data in three locations:
 
@@ -164,7 +166,7 @@ Claude Code stores project data in three locations:
 
 This script handles all three, ensuring your session history follows your project.
 
-### Migration Sequence
+### 🔄 Migration Sequence
 
 1. Backup `history.jsonl`
 2. Move project folder to destination
@@ -173,22 +175,22 @@ This script handles all three, ensuring your session history follows your projec
 
 If any step fails, all changes are automatically rolled back.
 
-### Fix Operation
+### 🔧 Fix Operation
 
 The most common scenario: you already moved a folder with `mv` and Claude sessions broke.
 
 ```bash
 # Auto-detect: scans for broken entries, tries to match by project name
-claude-move-project --fix
+clamp --fix
 
 # Point to the new location: auto-finds the broken old entry
-claude-move-project --fix ~/new/location/my-project
+clamp --fix ~/new/location/my-project
 
 # Explicit: specify both old and new paths
-claude-move-project --fix --from ~/old/path --to ~/new/path
+clamp --fix --from ~/old/path --to ~/new/path
 ```
 
-### Archive Format (.claudepack)
+### 📦 Archive Format (.claudepack)
 
 The `--pack` command creates a tar.gz archive with this structure:
 
@@ -202,7 +204,7 @@ project-name.claudepack
 
 When unpacking, paths are automatically rewritten to match the new destination.
 
-## Testing
+## 🧪 Testing
 
 Run the test suite to verify the script works correctly:
 
@@ -230,13 +232,13 @@ The test suite covers:
 - `--info` output
 - `--fix` (explicit paths, auto-detect, nothing broken)
 
-## Supported Platforms
+## 🖥️ Supported Platforms
 
 | Platform | Status |
 |----------|--------|
-| macOS | Fully supported |
-| Linux | Supported |
-| Windows | Via WSL or Git Bash |
+| macOS | ✅ Fully supported |
+| Linux | ✅ Supported |
+| Windows | ⚠️ Via WSL or Git Bash |
 
 ### Windows Users
 
@@ -246,7 +248,7 @@ This script requires a bash environment. Windows users can run it using:
 1. Install WSL2: `wsl --install` in PowerShell (admin)
 2. Open your WSL distro (e.g., Ubuntu)
 3. Navigate to your project: `cd /mnt/c/Users/YourName/projects/myproject`
-4. Run: `./claude-move-project ./my-project /mnt/c/new-location`
+4. Run: `./clamp ./my-project /mnt/c/new-location`
 
 **Option 2: Git Bash**
 1. Install [Git for Windows](https://git-scm.com/download/win) (includes Git Bash)

--- a/clamp
+++ b/clamp
@@ -1,18 +1,18 @@
 #!/bin/bash
 #
-# claude-move-project - Move a Claude Code project with session history
+# clamp - Move a Claude Code project with session history
 #
 # Copyright (c) 2025 WEB Solutions Ltd. (ws.agency) & Kristijan Lukačin
 # https://ws.agency
 #
 # Licensed under the MIT License. See LICENSE file for details.
 #
-# Usage: claude-move-project [OPTIONS] <source> <destination>
+# Usage: clamp [OPTIONS] <source> <destination>
 #
 
 set -euo pipefail
 
-VERSION="1.2.0"
+VERSION="1.3.0"
 CLAUDE_DIR="$HOME/.claude"
 PROJECTS_DIR="$CLAUDE_DIR/projects"
 HISTORY_FILE="$CLAUDE_DIR/history.jsonl"
@@ -70,20 +70,20 @@ log_error() {
 
 show_help() {
     cat << EOF
-claude-move-project v$VERSION
+clamp v$VERSION
 Move, remove, pack, unpack, list, fix, verify, or inspect Claude Code projects.
 
 Usage:
-  claude-move-project [OPTIONS] <source> <destination>
-  claude-move-project --here [OPTIONS] <source>
-  claude-move-project --remove [OPTIONS] <project-path>
-  claude-move-project --pack [OPTIONS] <project-path> [archive-path]
-  claude-move-project --unpack [OPTIONS] <archive-path> <destination>
-  claude-move-project --list [--json]
-  claude-move-project --fix [project-path]
-  claude-move-project --fix --from <old-path> --to <new-path>
-  claude-move-project --verify
-  claude-move-project --info <project-path>
+  clamp [OPTIONS] <source> <destination>
+  clamp --here [OPTIONS] <source>
+  clamp --remove [OPTIONS] <project-path>
+  clamp --pack [OPTIONS] <project-path> [archive-path]
+  clamp --unpack [OPTIONS] <archive-path> <destination>
+  clamp --list [--json]
+  clamp --fix [project-path]
+  clamp --fix --from <old-path> --to <new-path>
+  clamp --verify
+  clamp --info <project-path>
 
 Operations:
   (default)           Move project to new location
@@ -115,27 +115,27 @@ Options:
 
 Examples:
   # Move project
-  claude-move-project ./my-project ~/new-location/my-project
-  claude-move-project --here ~/old-location/my-project
-  claude-move-project ./project ~/deep/nested/path -p
+  clamp ./my-project ~/new-location/my-project
+  clamp --here ~/old-location/my-project
+  clamp ./project ~/deep/nested/path -p
 
   # Remove project and all session data
-  claude-move-project --remove ./my-project
+  clamp --remove ./my-project
 
   # Pack/unpack project
-  claude-move-project --pack ./my-project
-  claude-move-project --unpack backup.claudepack ~/projects/my-project
+  clamp --pack ./my-project
+  clamp --unpack backup.claudepack ~/projects/my-project
 
   # List, inspect, and maintain
-  claude-move-project --list
-  claude-move-project --list --json
-  claude-move-project --info ./my-project
-  claude-move-project --verify
+  clamp --list
+  clamp --list --json
+  clamp --info ./my-project
+  clamp --verify
 
   # Fix broken references after manual mv
-  claude-move-project --fix                              # auto-detect
-  claude-move-project --fix /new/location/my-project     # find old path
-  claude-move-project --fix --from /old/path --to /new/path
+  clamp --fix                              # auto-detect
+  clamp --fix /new/location/my-project     # find old path
+  clamp --fix --from /old/path --to /new/path
 
 What gets migrated:
   - Project folder (moved/copied/deleted based on operation)
@@ -318,7 +318,7 @@ parse_args() {
                 exit 0
                 ;;
             --version)
-                echo "claude-move-project v$VERSION"
+                echo "clamp v$VERSION"
                 exit 0
                 ;;
             --remove)
@@ -410,7 +410,7 @@ parse_args() {
         fi
         if [[ "$arg1_set" == false ]]; then
             log_error "Source path required with --here"
-            echo "Usage: claude-move-project --here <source>"
+            echo "Usage: clamp --here <source>"
             exit 1
         fi
         SOURCE="$ARG1"
@@ -489,7 +489,7 @@ parse_args() {
         info)
             if [[ "$arg1_set" == false ]]; then
                 log_error "Project path required"
-                echo "Usage: claude-move-project --info <project-path>"
+                echo "Usage: clamp --info <project-path>"
                 exit 1
             fi
             SOURCE="$ARG1"
@@ -1175,7 +1175,7 @@ EOF
     echo "Size: $archive_size"
     echo ""
     echo "To unpack on another machine:"
-    echo "  claude-move-project --unpack $ARCHIVE_PATH <destination>"
+    echo "  clamp --unpack $ARCHIVE_PATH <destination>"
 }
 
 # Execute unpack operation
@@ -1469,7 +1469,7 @@ execute_list() {
         echo ""
         echo "Total: $project_count projects ($healthy healthy, $broken broken)"
         if [[ $broken -gt 0 ]]; then
-            echo -e "${YELLOW}Run 'claude-move-project --fix' to repair broken references${NC}"
+            echo -e "${YELLOW}Run 'clamp --fix' to repair broken references${NC}"
         fi
     fi
 }
@@ -1590,7 +1590,7 @@ execute_verify() {
         echo -e "${GREEN}All checks passed! No issues found.${NC}"
     else
         echo -e "${YELLOW}Found $issues issue(s).${NC}"
-        echo "Run 'claude-move-project --fix' to attempt automatic repair."
+        echo "Run 'clamp --fix' to attempt automatic repair."
     fi
 }
 
@@ -1813,7 +1813,7 @@ execute_fix_detect_old() {
 
     if [[ $candidate_count -eq 0 ]]; then
         log_warn "No broken references found matching '$new_name'"
-        echo "Try: claude-move-project --fix --from <old-path> --to $new_path"
+        echo "Try: clamp --fix --from <old-path> --to $new_path"
         return 1
     elif [[ $candidate_count -eq 1 ]]; then
         local first_candidate
@@ -1948,7 +1948,7 @@ execute_fix_auto() {
 
         if [[ $match_count -eq 0 ]]; then
             echo "    No matching directory found. Use:"
-            echo "    claude-move-project --fix --from \"$bp\" --to <new-path>"
+            echo "    clamp --fix --from \"$bp\" --to <new-path>"
         elif [[ $match_count -eq 1 ]]; then
             local single_match
             single_match=$(echo "$matches" | head -1)

--- a/test.sh
+++ b/test.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 #
-# test.sh - Test suite for claude-move-project
+# test.sh - Test suite for clamp
 #
 # Usage: ./test.sh [test_name]
 #   Run all tests: ./test.sh
@@ -20,7 +20,7 @@ NC='\033[0m'
 TEST_DIR=""
 MOCK_CLAUDE_DIR=""
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-SCRIPT="$SCRIPT_DIR/claude-move-project"
+SCRIPT="$SCRIPT_DIR/clamp"
 
 # Test counters
 TESTS_PASSED=0
@@ -691,7 +691,7 @@ test_fix_nothing_broken() {
 
 main() {
     echo ""
-    echo "Claude Move Project Test Suite"
+    echo "clamp Test Suite"
     echo "==============================="
     echo ""
 


### PR DESCRIPTION
## Summary

- **BREAKING**: Executable renamed from `claude-move-project` to `clamp` (**CL**aude **A**I **M**ove **P**roject)
- Version bumped to v1.3.0
- All references updated across README.md, CLAUDE.md, and test.sh
- All 31 tests pass with the new name

## Test plan

- [x] `bash test.sh` — all 31 tests pass
- [x] `./clamp --version` outputs `clamp v1.3.0`
- [x] `./clamp --help` shows updated usage

🤖 Generated with [Claude Code](https://claude.com/claude-code)