### PR TITLE
feat: add Homebrew install and fix spurious rollback on empty args

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,14 @@ A bash utility that moves Claude Code projects while preserving all session hist
 
 ## Installation
 
+### Homebrew (macOS/Linux)
+
+```bash
+brew install wsagency/tap/clamp
+```
+
+### Manual
+
 ```bash
 git clone https://github.com/wsagency/claude-move-project.git
 cd claude-move-project

--- a/clamp
+++ b/clamp
@@ -218,7 +218,13 @@ cleanup() {
         log_verbose "Cleaned up temp directory: $TEMP_DIR"
     fi
 
-    if [[ $exit_code -ne 0 && "$DRY_RUN" == false ]]; then
+    # Only perform rollback if an operation actually started modifying state
+    local has_state_to_rollback=false
+    if [[ -n "$BACKUP_FILE" || "$PROJECT_FOLDER_MOVED" == true || "$HISTORY_FOLDER_MOVED" == true || "$HISTORY_MODIFIED" == true ]]; then
+        has_state_to_rollback=true
+    fi
+
+    if [[ $exit_code -ne 0 && "$DRY_RUN" == false && "$has_state_to_rollback" == true ]]; then
         echo ""
         log_error "Operation failed! Initiating rollback..."
 
@@ -2028,6 +2034,10 @@ execute() {
 
 # Main
 main() {
+    if [[ $# -eq 0 ]]; then
+        show_help
+        exit 0
+    fi
     parse_args "$@"
     validate
     show_preview


### PR DESCRIPTION
## Summary

- Add Homebrew tap install instructions to README (`brew install wsagency/tap/clamp`)
- Show help and exit cleanly when `clamp` is run with no arguments (instead of error + misleading rollback)
- Only display rollback messages when operations have actually started modifying state, preventing spurious "Initiating rollback..." output on validation errors

## Test plan

- [ ] `clamp` with no args shows help and exits 0 (no rollback message)
- [ ] `clamp nonexistent` shows error without rollback message
- [ ] `clamp nonexistent /tmp/dest` shows error without rollback message
- [ ] `bash test.sh` — all 31 tests pass
- [ ] `brew install wsagency/tap/clamp` installs successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)