### PR TITLE
feat: support CLAUDE_CONFIG_DIR for custom config location

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,6 +183,12 @@ Claude Code stores project data in three locations:
 
 This script handles all three, ensuring your session history follows your project.
 
+If you use a custom config directory via `CLAUDE_CONFIG_DIR`, clamp respects it automatically:
+
+```bash
+CLAUDE_CONFIG_DIR=~/custom-claude-config clamp ./my-project ~/new-location
+```
+
 ### 🔄 Migration Sequence
 
 1. Backup `history.jsonl`

--- a/clamp
+++ b/clamp
@@ -203,6 +203,31 @@ escape_for_sed() {
     printf '%s\n' "$str"
 }
 
+# Rewrite old paths to new paths inside session JSONL files
+# Usage: rewrite_session_paths <session_folder> <old_path> <new_path>
+rewrite_session_paths() {
+    local session_folder="$1"
+    local old_path="$2"
+    local new_path="$3"
+
+    if [[ ! -d "$session_folder" ]]; then
+        return 0
+    fi
+
+    local old_escaped new_escaped
+    old_escaped=$(escape_for_sed "$old_path")
+    new_escaped=$(escape_for_sed "$new_path")
+
+    find "$session_folder" -name "*.jsonl" -type f | while read -r jsonl_file; do
+        log_verbose "Updating session file: $jsonl_file"
+        if [[ "$(uname)" == "Darwin" ]]; then
+            sed -i '' "s|$old_escaped|$new_escaped|g" "$jsonl_file"
+        else
+            sed -i "s|$old_escaped|$new_escaped|g" "$jsonl_file"
+        fi
+    done
+}
+
 # Verbose logging (only when -v flag is set)
 log_verbose() {
     if [[ "$VERBOSE" == true ]]; then
@@ -1068,7 +1093,14 @@ execute_move() {
         log_success "Renamed history folder"
     fi
 
-    # Step 4: Update history.jsonl
+    # Step 4: Rewrite paths inside session JSONL files
+    if [[ -d "$PROJECTS_DIR/$NEW_ENCODED" ]]; then
+        log_info "Rewriting paths in session files..."
+        rewrite_session_paths "$PROJECTS_DIR/$NEW_ENCODED" "$SOURCE_ABS" "$DEST_ABS"
+        log_success "Rewrote paths in session files"
+    fi
+
+    # Step 5: Update history.jsonl
     if [[ -f "$HISTORY_FILE" ]]; then
         log_info "Updating history index..."
         # Escape special characters for sed (handles [], *, ., ^, $, etc.)
@@ -1271,19 +1303,7 @@ execute_unpack() {
         # Rewrite paths in session JSONL files
         if [[ -n "$original_path" && "$original_path" != "$DEST_ABS" ]]; then
             log_info "Rewriting paths in session files..."
-            local old_escaped new_escaped
-            old_escaped=$(escape_for_sed "$original_path")
-            new_escaped=$(escape_for_sed "$DEST_ABS")
-
-            # Find and update all JSONL files
-            find "$PROJECTS_DIR/$NEW_ENCODED" -name "*.jsonl" -type f | while read -r jsonl_file; do
-                log_verbose "Updating: $jsonl_file"
-                if [[ "$(uname)" == "Darwin" ]]; then
-                    sed -i '' "s|$old_escaped|$new_escaped|g" "$jsonl_file"
-                else
-                    sed -i "s|$old_escaped|$new_escaped|g" "$jsonl_file"
-                fi
-            done
+            rewrite_session_paths "$PROJECTS_DIR/$NEW_ENCODED" "$original_path" "$DEST_ABS"
             log_success "Rewrote paths in session files"
         fi
         log_success "Copied session folder"
@@ -1880,6 +1900,13 @@ execute_fix_explicit() {
             mv "$PROJECTS_DIR/$old_encoded" "$PROJECTS_DIR/$new_encoded"
             log_success "Renamed session folder"
         fi
+    fi
+
+    # Rewrite paths inside session JSONL files
+    if [[ -d "$PROJECTS_DIR/$new_encoded" ]]; then
+        log_info "Rewriting paths in session files..."
+        rewrite_session_paths "$PROJECTS_DIR/$new_encoded" "$old_path" "$new_path"
+        log_success "Rewrote paths in session files"
     fi
 
     # Update history.jsonl

--- a/clamp
+++ b/clamp
@@ -13,7 +13,7 @@
 set -euo pipefail
 
 VERSION="1.4.1"
-CLAUDE_DIR="$HOME/.claude"
+CLAUDE_DIR="${CLAUDE_CONFIG_DIR:-$HOME/.claude}"
 PROJECTS_DIR="$CLAUDE_DIR/projects"
 HISTORY_FILE="$CLAUDE_DIR/history.jsonl"
 

--- a/test.sh
+++ b/test.sh
@@ -799,6 +799,120 @@ test_case_insensitive_path() {
 }
 
 # ============================================================================
+# CLAUDE_CONFIG_DIR TESTS
+# ============================================================================
+
+test_claude_config_dir_move() {
+    # Set up a custom config dir (not under $HOME/.claude)
+    local custom_config="$TEST_DIR/custom-config"
+    mkdir -p "$custom_config/projects"
+    touch "$custom_config/history.jsonl"
+
+    # Remove the default $HOME/.claude so we can verify it's not used
+    rm -rf "$MOCK_CLAUDE_DIR"
+
+    # Create source project and its session data in custom config dir
+    local source_abs="$TEST_DIR/source-project"
+    mkdir -p "$source_abs/.claude"
+    echo "# Test" > "$source_abs/README.md"
+
+    local encoded="${source_abs//\//-}"
+    mkdir -p "$custom_config/projects/$encoded"
+    echo "{\"type\":\"session\",\"cwd\":\"$source_abs\"}" > "$custom_config/projects/$encoded/session1.jsonl"
+    echo "{\"project\":\"$source_abs\",\"session\":\"session1\"}" >> "$custom_config/history.jsonl"
+
+    local dest_abs="$TEST_DIR/dest-project"
+
+    # Run with CLAUDE_CONFIG_DIR
+    CLAUDE_CONFIG_DIR="$custom_config" "$SCRIPT" "$source_abs" "$dest_abs" -f
+
+    # Verify project moved
+    assert_not_exists "$source_abs" "Source should be gone" || return 1
+    assert_dir_exists "$dest_abs" "Destination should exist" || return 1
+
+    # Verify session folder renamed in custom config dir
+    local new_encoded="${dest_abs//\//-}"
+    assert_not_exists "$custom_config/projects/$encoded" "Old session folder should be gone" || return 1
+    assert_dir_exists "$custom_config/projects/$new_encoded" "New session folder should exist in custom config" || return 1
+
+    # Verify history.jsonl updated in custom config dir
+    assert_not_contains "$custom_config/history.jsonl" "$source_abs" "Old path should not be in history" || return 1
+    assert_contains "$custom_config/history.jsonl" "$dest_abs" "New path should be in history" || return 1
+
+    # Verify cwd rewritten inside session JSONL
+    assert_not_contains "$custom_config/projects/$new_encoded/session1.jsonl" "$source_abs" "Old cwd should not be in session file" || return 1
+    assert_contains "$custom_config/projects/$new_encoded/session1.jsonl" "$dest_abs" "New cwd should be in session file" || return 1
+
+    # Verify default $HOME/.claude was NOT created
+    assert_not_exists "$MOCK_CLAUDE_DIR" "Default ~/.claude should not be created" || return 1
+}
+
+test_claude_config_dir_list() {
+    # Set up a custom config dir
+    local custom_config="$TEST_DIR/custom-config"
+    mkdir -p "$custom_config/projects"
+    touch "$custom_config/history.jsonl"
+
+    # Remove the default $HOME/.claude
+    rm -rf "$MOCK_CLAUDE_DIR"
+
+    # Create a project entry in custom config
+    local project_abs="$TEST_DIR/listed-project"
+    mkdir -p "$project_abs"
+    echo "{\"project\":\"$project_abs\",\"session\":\"s1\"}" >> "$custom_config/history.jsonl"
+
+    local output
+    output=$(CLAUDE_CONFIG_DIR="$custom_config" "$SCRIPT" --list 2>&1)
+
+    if echo "$output" | grep -q "listed-project"; then
+        return 0
+    else
+        echo "  Expected project in --list output"
+        echo "  Output: $output"
+        return 1
+    fi
+}
+
+test_claude_config_dir_fix() {
+    # Set up a custom config dir
+    local custom_config="$TEST_DIR/custom-config"
+    mkdir -p "$custom_config/projects"
+    touch "$custom_config/history.jsonl"
+
+    # Remove the default $HOME/.claude
+    rm -rf "$MOCK_CLAUDE_DIR"
+
+    # Create project, simulate manual mv
+    local old_abs="$TEST_DIR/fix-old"
+    mkdir -p "$old_abs/.claude"
+    echo "# Test" > "$old_abs/README.md"
+
+    local old_encoded="${old_abs//\//-}"
+    mkdir -p "$custom_config/projects/$old_encoded"
+    echo "{\"type\":\"session\",\"cwd\":\"$old_abs\"}" > "$custom_config/projects/$old_encoded/session1.jsonl"
+    echo "{\"project\":\"$old_abs\",\"session\":\"s1\"}" >> "$custom_config/history.jsonl"
+
+    # Manual mv
+    mv "$old_abs" "$TEST_DIR/fix-new"
+    local new_abs="$TEST_DIR/fix-new"
+
+    # Run fix with CLAUDE_CONFIG_DIR
+    CLAUDE_CONFIG_DIR="$custom_config" "$SCRIPT" --fix --from "$old_abs" --to "$new_abs" -f
+
+    # Verify session folder renamed
+    local new_encoded="${new_abs//\//-}"
+    assert_not_exists "$custom_config/projects/$old_encoded" "Old session folder should be gone" || return 1
+    assert_dir_exists "$custom_config/projects/$new_encoded" "New session folder should exist" || return 1
+
+    # Verify history updated
+    assert_contains "$custom_config/history.jsonl" "$new_abs" "History should have new path" || return 1
+    assert_not_contains "$custom_config/history.jsonl" "$old_abs" "History should not have old path" || return 1
+
+    # Verify cwd rewritten in session file
+    assert_contains "$custom_config/projects/$new_encoded/session1.jsonl" "$new_abs" "Session file should have new cwd" || return 1
+}
+
+# ============================================================================
 # MAIN
 # ============================================================================
 
@@ -854,6 +968,10 @@ main() {
         test_prune_dry_run
         # case-sensitivity tests
         test_case_insensitive_path
+        # CLAUDE_CONFIG_DIR tests
+        test_claude_config_dir_move
+        test_claude_config_dir_list
+        test_claude_config_dir_fix
     )
 
     # Run specific test or all tests


### PR DESCRIPTION
## Summary

- Respect the `CLAUDE_CONFIG_DIR` environment variable instead of always using `~/.claude`, falls back to `~/.claude` when unset (no breaking change)
- Added usage example to README
- Fix: rewrite `cwd` paths inside session JSONL files during `move` and `fix` operations

## Problem

The `move` and `fix` operations renamed the session folder and updated `history.jsonl`, but never rewrote the `cwd` field inside session JSONL files. Claude's `claude -r` reads `cwd` from those files to display the project path in the resume list, so moved projects still showed their old location.

## Solution

Extract `rewrite_session_paths` helper from the `unpack` operation (which already did this correctly) and call it from `execute_move` and `execute_fix_explicit` as well.

## Test plan

- [x] `clamp ./proj ~/new-loc` — verify `claude -r` shows new path
- [x] `clamp --fix --from /old/path --to /new/path` — verify `claude -r` shows new path
- [x] `clamp --list` without `CLAUDE_CONFIG_DIR` — should use `~/.claude` as before
- [x] `CLAUDE_CONFIG_DIR=/tmp/test clamp --list` — should look in `/tmp/test`
- [x] `clamp --dry-run` with custom dir to verify all paths resolve correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)