### PR TITLE
fix: enforce LF line endings for clamp script

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+clamp text eol=lf


### PR DESCRIPTION
Add `.gitattributes` to force LF line endings for the `clamp` script.

Without this, Windows users with `core.autocrlf=true` get CRLF on checkout, which breaks the script when run via WSL/bash (`$'\r': command not found`).