### PR TITLE
add `--encoding windows`

### DIFF
--- a/clamp
+++ b/clamp
@@ -51,6 +51,7 @@ JSON_OUTPUT=false
 HERE_MODE=false
 FIX_FROM=""
 FIX_TO=""
+PATH_ENCODING="posix"  # posix | windows; set via --encoding
 
 log_info() {
     echo -e "${BLUE}[INFO]${NC} $1"
@@ -111,6 +112,7 @@ Options:
   --json              Output in JSON format (for --list)
   --from <path>       Original path (for --fix)
   --to <path>         New path (for --fix)
+  --encoding <mode>   Path-encoding scheme: posix (default) or windows
   -v, --verbose       Show detailed output
   -h, --help          Show this help message
   --version           Show version
@@ -147,22 +149,51 @@ What gets migrated:
 EOF
 }
 
-# Convert path to Claude's encoded format: /path/to/dir -> -path-to-dir
+# Convert path to Claude's encoded format.
 encode_path() {
     local path="$1"
+    if [[ "$PATH_ENCODING" == "windows" ]]; then
+        # Normalize Git Bash mounted-drive form (/d/foo) to native (D:/foo)
+        if [[ "$path" =~ ^/([a-zA-Z])/(.*)$ ]]; then
+            local drive
+            drive=$(echo "${BASH_REMATCH[1]}" | tr '[:lower:]' '[:upper:]')
+            path="${drive}:/${BASH_REMATCH[2]}"
+        fi
+        # Claude on Windows encodes : and \ to -, then / to -
+        path="${path//:/-}"
+        path="${path//\\/-}"
+    fi
     echo "${path//\//-}"
 }
 
-# Get absolute path (works on macOS and Linux)
+# Convert a filesystem-form path to history.jsonl form.
+to_history_form() {
+    local path="$1"
+    if [[ "$PATH_ENCODING" == "windows" ]]; then
+        local bs='\\\\'
+        path="${path//\//$bs}"
+    fi
+    echo "$path"
+}
+
+# Inverse of to_history_form.
+from_history_form() {
+    local path="$1"
+    if [[ "$PATH_ENCODING" == "windows" ]]; then
+        path="${path//\\\\//}"
+    fi
+    echo "$path"
+}
+
+# Get absolute path (macOS, Linux, MSYS).
 # Recursively resolves paths even when destination doesn't exist
 get_absolute_path() {
     local path="$1"
+    local resolved
     if [[ -d "$path" ]]; then
-        (cd "$path" && pwd)
+        resolved=$(cd "$path" && pwd)
     elif [[ -f "$path" ]]; then
-        local dir
-        dir=$(dirname "$path")
-        echo "$(cd "$dir" && pwd)/$(basename "$path")"
+        resolved="$(cd "$(dirname "$path")" && pwd)/$(basename "$path")"
     else
         # Path doesn't exist yet, resolve via parent
         local parent
@@ -170,20 +201,32 @@ get_absolute_path() {
         local base
         base=$(basename "$path")
         if [[ -d "$parent" ]]; then
-            echo "$(cd "$parent" && pwd)/$base"
+            resolved="$(cd "$parent" && pwd)/$base"
         else
             # Try to resolve parent recursively
             local resolved_parent
             resolved_parent=$(get_absolute_path "$parent")
-            echo "$resolved_parent/$base"
+            resolved="$resolved_parent/$base"
         fi
     fi
+    if [[ "$PATH_ENCODING" == "windows" ]]; then
+        # Rewrite forward-slash paths to match format in history.jsonl.
+        if [[ "$resolved" =~ ^/([a-zA-Z])/(.*)$ ]]; then
+            local drive
+            drive=$(echo "${BASH_REMATCH[1]}" | tr '[:lower:]' '[:upper:]')
+            resolved="${drive}:/${BASH_REMATCH[2]}"
+        fi
+    fi
+    echo "$resolved"
 }
 
-# Validate that a path is absolute (starts with /)
+# Validate that a path is absolute
+#   POSIX:   starts with /
+#   Windows: starts with <letter>:/ or <letter>:\
 is_absolute_path() {
     local path="$1"
-    [[ "$path" == /* ]]
+    [[ "$path" == /* ]] && return 0
+    [[ "$path" =~ ^[a-zA-Z]:[/\\] ]]
 }
 
 # Escape special characters for sed regex patterns
@@ -208,6 +251,51 @@ log_verbose() {
     if [[ "$VERBOSE" == true ]]; then
         echo -e "${BLUE}[VERBOSE]${NC} $1"
     fi
+}
+
+# sed -i wrapper that handles the macOS vs Linux argument difference.
+_sed_inplace() {
+    if [[ "$(uname)" == "Darwin" ]]; then
+        sed -i '' "$@"
+    else
+        sed -i "$@"
+    fi
+}
+
+# Wrapper around `read -p` that always reads from the controlling terminal.
+# (bare `read -p` silently consumes stdin ignoring redirection.)
+prompt_read() {
+    local prompt="$1"
+    shift
+    read -p "$prompt" "$@" < /dev/tty
+}
+
+# Rewrite "project":"<old_fs>" -> "project":"<new_fs>" in a single
+# history-format file (history.jsonl or an extracted-entries staging file).
+rewrite_project_key_in_history_jsonl() {
+    local file="$1" old_fs="$2" new_fs="$3"
+    [[ -f "$file" ]] || return 0
+    [[ "$old_fs" == "$new_fs" ]] && return 0
+    local old_escaped new_escaped
+    old_escaped=$(escape_for_sed "$(to_history_form "$old_fs")")
+    new_escaped=$(escape_for_sed "$(to_history_form "$new_fs")")
+    _sed_inplace "s|\"project\":\"$old_escaped\"|\"project\":\"$new_escaped\"|g" "$file"
+}
+
+# Rewrite every occurrence of <old_fs> -> <new_fs> in every *.jsonl file under <dir>.
+# Used for per-session transcript JSONLs, where the project path can
+# appear in multiple fields (cwd, file refs, etc).
+rewrite_paths_in_session_jsonls() {
+    local dir="$1" old_fs="$2" new_fs="$3"
+    [[ -d "$dir" ]] || return 0
+    [[ "$old_fs" == "$new_fs" ]] && return 0
+    local old_escaped new_escaped
+    old_escaped=$(escape_for_sed "$(to_history_form "$old_fs")")
+    new_escaped=$(escape_for_sed "$(to_history_form "$new_fs")")
+    find "$dir" -name "*.jsonl" -type f | while read -r jsonl_file; do
+        log_verbose "Rewriting paths in: $jsonl_file"
+        _sed_inplace "s|$old_escaped|$new_escaped|g" "$jsonl_file"
+    done
 }
 
 # Rollback on failure
@@ -315,6 +403,23 @@ parse_args() {
                     exit 1
                 fi
                 FIX_TO="$1"
+                shift
+                ;;
+            --encoding)
+                shift
+                if [[ $# -eq 0 ]]; then
+                    log_error "--encoding requires an argument (posix|windows)"
+                    exit 1
+                fi
+                case "$1" in
+                    posix|windows)
+                        PATH_ENCODING="$1"
+                        ;;
+                    *)
+                        log_error "--encoding must be 'posix' or 'windows' (got: $1)"
+                        exit 1
+                        ;;
+                esac
                 shift
                 ;;
             -v|--verbose)
@@ -532,19 +637,19 @@ validate_source_project() {
     SOURCE_ABS=$(get_absolute_path "$SOURCE")
     log_verbose "Resolved source path: $SOURCE_ABS"
 
-    # On case-insensitive filesystems (macOS APFS), `cd "$path" && pwd` preserves
-    # the casing of the input, not the canonical filesystem casing. If the user's
-    # shell resolves a different case than what Claude Code stored in history.jsonl,
-    # the sed replacement will silently match nothing. Fix by looking up the
-    # canonical path string from history.jsonl via case-insensitive match.
-    if [[ -f "$HISTORY_FILE" ]] && ! grep -qF -- "\"project\":\"$SOURCE_ABS\"" "$HISTORY_FILE"; then
+    # On case-insensitive filesystems (macOS APFS, Windows NTFS),
+    # `cd && pwd` preserves the casing of the input, not the canonical casing.
+    # Look up the canonical string in history.jsonl (case-insensitive match).
+    if [[ -f "$HISTORY_FILE" ]] && ! grep -qF -- "\"project\":\"$(to_history_form "$SOURCE_ABS")\"" "$HISTORY_FILE"; then
         local ci_match
-        ci_match=$(grep -iF -- "\"project\":\"$SOURCE_ABS\"" "$HISTORY_FILE" | head -1 | sed -n 's/.*"project":"\([^"]*\)".*/\1/p') || true
+        ci_match=$(grep -iF -- "\"project\":\"$(to_history_form "$SOURCE_ABS")\"" "$HISTORY_FILE" | head -1 | sed -n 's/.*"project":"\([^"]*\)".*/\1/p') || true
         if [[ -n "$ci_match" ]]; then
+            local ci_match_fs
+            ci_match_fs=$(from_history_form "$ci_match")
             log_warn "Path case mismatch detected (case-insensitive filesystem)"
             log_verbose "  Shell resolved: $SOURCE_ABS"
-            log_verbose "  History record: $ci_match"
-            SOURCE_ABS="$ci_match"
+            log_verbose "  History record: $ci_match_fs"
+            SOURCE_ABS="$ci_match_fs"
         fi
     fi
 
@@ -828,7 +933,7 @@ show_preview_move() {
     # Count history.jsonl entries
     if [[ -f "$HISTORY_FILE" ]]; then
         local entry_count
-        entry_count=$(grep -c -F -- "\"project\":\"$SOURCE_ABS\"" "$HISTORY_FILE" 2>/dev/null) || entry_count=0
+        entry_count=$(grep -c -F -- "\"project\":\"$(to_history_form "$SOURCE_ABS")\"" "$HISTORY_FILE" 2>/dev/null) || entry_count=0
         echo "History Index Updates:"
         echo "  File: $HISTORY_FILE"
         echo "  Entries to update: $entry_count reference(s)"
@@ -877,7 +982,7 @@ show_preview_remove() {
     # Count history.jsonl entries to remove
     if [[ -f "$HISTORY_FILE" ]]; then
         local entry_count
-        entry_count=$(grep -c -F -- "\"project\":\"$SOURCE_ABS\"" "$HISTORY_FILE" 2>/dev/null) || entry_count=0
+        entry_count=$(grep -c -F -- "\"project\":\"$(to_history_form "$SOURCE_ABS")\"" "$HISTORY_FILE" 2>/dev/null) || entry_count=0
         echo "History Index Entries to REMOVE: $entry_count"
     fi
     echo ""
@@ -919,7 +1024,7 @@ show_preview_pack() {
     # Count history.jsonl entries
     if [[ -f "$HISTORY_FILE" ]]; then
         local entry_count
-        entry_count=$(grep -c -F -- "\"project\":\"$SOURCE_ABS\"" "$HISTORY_FILE" 2>/dev/null) || entry_count=0
+        entry_count=$(grep -c -F -- "\"project\":\"$(to_history_form "$SOURCE_ABS")\"" "$HISTORY_FILE" 2>/dev/null) || entry_count=0
         echo "History Index Entries: $entry_count"
     fi
     echo ""
@@ -1034,7 +1139,7 @@ confirm() {
             ;;
     esac
 
-    read -p "$prompt" -n 1 -r
+    prompt_read "$prompt" -n 1 -r
     echo ""
     if [[ ! $REPLY =~ ^[Yy]$ ]]; then
         log_info "$action_name cancelled"
@@ -1071,21 +1176,15 @@ execute_move() {
     # Step 4: Update history.jsonl
     if [[ -f "$HISTORY_FILE" ]]; then
         log_info "Updating history index..."
-        # Escape special characters for sed (handles [], *, ., ^, $, etc.)
-        local old_escaped
-        local new_escaped
-        old_escaped=$(escape_for_sed "$SOURCE_ABS")
-        new_escaped=$(escape_for_sed "$DEST_ABS")
-        log_verbose "Escaped source for sed: $old_escaped"
-        log_verbose "Escaped destination for sed: $new_escaped"
-
-        # macOS sed requires '' after -i, Linux doesn't
-        if [[ "$(uname)" == "Darwin" ]]; then
-            sed -i '' "s|\"project\":\"$old_escaped\"|\"project\":\"$new_escaped\"|g" "$HISTORY_FILE"
-        else
-            sed -i "s|\"project\":\"$old_escaped\"|\"project\":\"$new_escaped\"|g" "$HISTORY_FILE"
-        fi
+        rewrite_project_key_in_history_jsonl "$HISTORY_FILE" "$SOURCE_ABS" "$DEST_ABS"
         log_success "Updated history index"
+    fi
+
+    # Step 5: Rewrite path references inside per-session JSONL files.
+    if [[ -d "$PROJECTS_DIR/$NEW_ENCODED" ]]; then
+        log_info "Rewriting paths in session transcripts..."
+        rewrite_paths_in_session_jsonls "$PROJECTS_DIR/$NEW_ENCODED" "$SOURCE_ABS" "$DEST_ABS"
+        log_success "Rewrote paths in session transcripts"
     fi
 
     echo ""
@@ -1110,10 +1209,8 @@ execute_remove() {
     # Step 2: Remove entries from history.jsonl
     if [[ -f "$HISTORY_FILE" ]]; then
         log_info "Removing entries from history index..."
-        local old_escaped
-        old_escaped=$(escape_for_sed "$SOURCE_ABS")
-        # Create temp file without matching lines
-        grep -v -F "\"project\":\"$SOURCE_ABS\"" "$HISTORY_FILE" > "$HISTORY_FILE.tmp" || true
+        # Filter via fixed-string grep (no sed-escape needed).
+        grep -v -F "\"project\":\"$(to_history_form "$SOURCE_ABS")\"" "$HISTORY_FILE" > "$HISTORY_FILE.tmp" || true
         mv "$HISTORY_FILE.tmp" "$HISTORY_FILE"
         HISTORY_MODIFIED=true
         log_success "Removed history index entries"
@@ -1165,7 +1262,7 @@ execute_pack() {
     # Step 3: Extract history entries
     log_info "Extracting history entries..."
     if [[ -f "$HISTORY_FILE" ]]; then
-        grep -F "\"project\":\"$SOURCE_ABS\"" "$HISTORY_FILE" > "$TEMP_DIR/history-entries.jsonl" || true
+        grep -F "\"project\":\"$(to_history_form "$SOURCE_ABS")\"" "$HISTORY_FILE" > "$TEMP_DIR/history-entries.jsonl" || true
     else
         touch "$TEMP_DIR/history-entries.jsonl"
     fi
@@ -1268,22 +1365,10 @@ execute_unpack() {
         cp -R "$TEMP_DIR/sessions/." "$PROJECTS_DIR/$NEW_ENCODED/"
         HISTORY_FOLDER_MOVED=true
 
-        # Rewrite paths in session JSONL files
+        # Rewrite paths in session JSONL files (same format as history.jsonl).
         if [[ -n "$original_path" && "$original_path" != "$DEST_ABS" ]]; then
             log_info "Rewriting paths in session files..."
-            local old_escaped new_escaped
-            old_escaped=$(escape_for_sed "$original_path")
-            new_escaped=$(escape_for_sed "$DEST_ABS")
-
-            # Find and update all JSONL files
-            find "$PROJECTS_DIR/$NEW_ENCODED" -name "*.jsonl" -type f | while read -r jsonl_file; do
-                log_verbose "Updating: $jsonl_file"
-                if [[ "$(uname)" == "Darwin" ]]; then
-                    sed -i '' "s|$old_escaped|$new_escaped|g" "$jsonl_file"
-                else
-                    sed -i "s|$old_escaped|$new_escaped|g" "$jsonl_file"
-                fi
-            done
+            rewrite_paths_in_session_jsonls "$PROJECTS_DIR/$NEW_ENCODED" "$original_path" "$DEST_ABS"
             log_success "Rewrote paths in session files"
         fi
         log_success "Copied session folder"
@@ -1293,17 +1378,10 @@ execute_unpack() {
     if [[ -f "$TEMP_DIR/history-entries.jsonl" ]] && [[ -s "$TEMP_DIR/history-entries.jsonl" ]]; then
         log_info "Appending history entries..."
 
-        # Rewrite paths in history entries before appending
+        # Rewrite paths in history entries before appending.
         if [[ -n "$original_path" && "$original_path" != "$DEST_ABS" ]]; then
-            local old_escaped new_escaped
-            old_escaped=$(escape_for_sed "$original_path")
-            new_escaped=$(escape_for_sed "$DEST_ABS")
-
-            if [[ "$(uname)" == "Darwin" ]]; then
-                sed -i '' "s|$old_escaped|$new_escaped|g" "$TEMP_DIR/history-entries.jsonl"
-            else
-                sed -i "s|$old_escaped|$new_escaped|g" "$TEMP_DIR/history-entries.jsonl"
-            fi
+            rewrite_project_key_in_history_jsonl \
+                "$TEMP_DIR/history-entries.jsonl" "$original_path" "$DEST_ABS"
         fi
 
         # Append to history file
@@ -1363,12 +1441,16 @@ _list_has() {
     echo "$list" | grep -qFx -- "$val" 2>/dev/null
 }
 
-# Extract unique project paths from history.jsonl
+# Extract unique project paths from history.jsonl, normalized to filesystem form.
 _extract_history_projects() {
-    if [[ -f "$HISTORY_FILE" ]]; then
-        grep -o '"project":"[^"]*"' "$HISTORY_FILE" 2>/dev/null | \
-            sed 's/"project":"//;s/"$//' | sort -u || true
+    if [[ ! -f "$HISTORY_FILE" ]]; then
+        return 0
     fi
+    grep -o '"project":"[^"]*"' "$HISTORY_FILE" 2>/dev/null | \
+        sed 's/"project":"//;s/"$//' | \
+        while IFS= read -r p; do
+            from_history_form "$p"
+        done | sort -u || true
 }
 
 # Execute list operation
@@ -1396,7 +1478,7 @@ execute_list() {
     if [[ -n "$seen" ]]; then
         while IFS= read -r kp; do
             [[ -z "$kp" ]] && continue
-            known_encoded="${known_encoded}${known_encoded:+$'\n'}${kp//\//-}"
+            known_encoded="${known_encoded}${known_encoded:+$'\n'}$(encode_path "$kp")"
         done <<< "$seen"
     fi
 
@@ -1423,7 +1505,7 @@ execute_list() {
 
     local project_count=0
     while IFS= read -r _p; do
-        [[ -n "$_p" ]] && ((project_count++))
+        [[ -n "$_p" ]] && { ((project_count++)) || true; }
     done <<< "$projects"
 
     if [[ "$JSON_OUTPUT" == true ]]; then
@@ -1432,7 +1514,8 @@ execute_list() {
         local first=true
         while IFS= read -r proj_path; do
             [[ -z "$proj_path" ]] && continue
-            local encoded="${proj_path//\//-}"
+            local encoded
+            encoded=$(encode_path "$proj_path")
             local sessions
             sessions=$(count_sessions "$encoded")
             local size="0"
@@ -1476,7 +1559,8 @@ execute_list() {
 
         while IFS= read -r proj_path; do
             [[ -z "$proj_path" ]] && continue
-            local encoded="${proj_path//\//-}"
+            local encoded
+            encoded=$(encode_path "$proj_path")
             local sessions
             sessions=$(count_sessions "$encoded")
             local status_icon status_label
@@ -1556,7 +1640,7 @@ execute_verify() {
     if [[ -n "$unique_projects" ]]; then
         while IFS= read -r pp; do
             [[ -z "$pp" ]] && continue
-            known_encoded="${known_encoded}${known_encoded:+$'\n'}${pp//\//-}"
+            known_encoded="${known_encoded}${known_encoded:+$'\n'}$(encode_path "$pp")"
         done <<< "$unique_projects"
     fi
 
@@ -1603,7 +1687,8 @@ execute_verify() {
         if [[ -n "$unique_hist" ]]; then
             while IFS= read -r proj_path; do
                 [[ -z "$proj_path" ]] && continue
-                local encoded="${proj_path//\//-}"
+                local encoded
+                encoded=$(encode_path "$proj_path")
                 if [[ -d "$proj_path" && ! -d "$PROJECTS_DIR/$encoded" ]]; then
                     if [[ $missing_sessions -eq 0 ]]; then
                         echo -e "  ${YELLOW}Projects with history entries but no session folder:${NC}"
@@ -1645,7 +1730,7 @@ execute_prune() {
     if [[ -n "$unique_projects" ]]; then
         while IFS= read -r pp; do
             [[ -z "$pp" ]] && continue
-            known_encoded="${known_encoded}${known_encoded:+$'\n'}${pp//\//-}"
+            known_encoded="${known_encoded}${known_encoded:+$'\n'}$(encode_path "$pp")"
         done <<< "$unique_projects"
     fi
 
@@ -1692,7 +1777,7 @@ execute_prune() {
 
     # Confirm
     if [[ "$FORCE" != true ]]; then
-        read -p "Remove $orphaned_count orphaned session folder(s)? [y/N] " -n 1 -r
+        prompt_read "Remove $orphaned_count orphaned session folder(s)? [y/N] " -n 1 -r
         echo ""
         if [[ ! $REPLY =~ ^[Yy]$ ]]; then
             log_info "Prune cancelled"
@@ -1721,7 +1806,8 @@ execute_prune() {
 
 # Execute info operation
 execute_info() {
-    local encoded="${SOURCE_ABS//\//-}"
+    local encoded
+    encoded=$(encode_path "$SOURCE_ABS")
 
     echo ""
     echo "Claude Code Project Info"
@@ -1784,7 +1870,7 @@ execute_info() {
     # History entries
     if [[ -f "$HISTORY_FILE" ]]; then
         local entry_count
-        entry_count=$(grep -c -F -- "\"project\":\"$SOURCE_ABS\"" "$HISTORY_FILE" 2>/dev/null) || entry_count=0
+        entry_count=$(grep -c -F -- "\"project\":\"$(to_history_form "$SOURCE_ABS")\"" "$HISTORY_FILE" 2>/dev/null) || entry_count=0
         echo "History entries: $entry_count"
     else
         echo "History entries: (history file not found)"
@@ -1814,8 +1900,10 @@ execute_fix() {
 execute_fix_explicit() {
     local old_path="$1"
     local new_path="$2"
-    local old_encoded="${old_path//\//-}"
-    local new_encoded="${new_path//\//-}"
+    local old_encoded
+    local new_encoded
+    old_encoded=$(encode_path "$old_path")
+    new_encoded=$(encode_path "$new_path")
 
     log_info "Fixing: $old_path → $new_path"
     echo ""
@@ -1836,7 +1924,7 @@ execute_fix_explicit() {
     # Check history entries
     local entry_count=0
     if [[ -f "$HISTORY_FILE" ]]; then
-        entry_count=$(grep -c -F -- "\"project\":\"$old_path\"" "$HISTORY_FILE" 2>/dev/null) || entry_count=0
+        entry_count=$(grep -c -F -- "\"project\":\"$(to_history_form "$old_path")\"" "$HISTORY_FILE" 2>/dev/null) || entry_count=0
         if [[ $entry_count -gt 0 ]]; then
             echo "History entries to update: $entry_count"
             changes=1
@@ -1857,7 +1945,7 @@ execute_fix_explicit() {
 
     # Confirm
     if [[ "$FORCE" != true ]]; then
-        read -p "Apply fix? [y/N] " -n 1 -r
+        prompt_read "Apply fix? [y/N] " -n 1 -r
         echo ""
         if [[ ! $REPLY =~ ^[Yy]$ ]]; then
             log_info "Fix cancelled"
@@ -1884,16 +1972,15 @@ execute_fix_explicit() {
 
     # Update history.jsonl
     if [[ -f "$HISTORY_FILE" && $entry_count -gt 0 ]]; then
-        local old_escaped new_escaped
-        old_escaped=$(escape_for_sed "$old_path")
-        new_escaped=$(escape_for_sed "$new_path")
-
-        if [[ "$(uname)" == "Darwin" ]]; then
-            sed -i '' "s|\"project\":\"$old_escaped\"|\"project\":\"$new_escaped\"|g" "$HISTORY_FILE"
-        else
-            sed -i "s|\"project\":\"$old_escaped\"|\"project\":\"$new_escaped\"|g" "$HISTORY_FILE"
-        fi
+        rewrite_project_key_in_history_jsonl "$HISTORY_FILE" "$old_path" "$new_path"
         log_success "Updated $entry_count history entries"
+    fi
+
+    # Rewrite path references inside per-session JSONL files 
+    if [[ -d "$PROJECTS_DIR/$new_encoded" ]]; then
+        log_info "Rewriting paths in session transcripts..."
+        rewrite_paths_in_session_jsonls "$PROJECTS_DIR/$new_encoded" "$old_path" "$new_path"
+        log_success "Rewrote paths in session transcripts"
     fi
 
     echo ""
@@ -1961,7 +2048,7 @@ execute_fix_detect_old() {
             log_info "Using first match (--force)"
             execute_fix_explicit "$first_candidate" "$new_path"
         else
-            read -p "Select which to fix (1-$candidate_count): " -r
+            prompt_read "Select which to fix (1-$candidate_count): " -r
             local idx=$((REPLY))
             local selected
             selected=$(echo "$candidates" | sed -n "${idx}p")
@@ -2006,7 +2093,7 @@ execute_fix_auto() {
     if [[ -n "$unique_projects" ]]; then
         while IFS= read -r kp; do
             [[ -z "$kp" ]] && continue
-            known_encoded="${known_encoded}${known_encoded:+$'\n'}${kp//\//-}"
+            known_encoded="${known_encoded}${known_encoded:+$'\n'}$(encode_path "$kp")"
         done <<< "$unique_projects"
     fi
 
@@ -2056,7 +2143,7 @@ execute_fix_auto() {
                 while IFS= read -r match; do
                     [[ -d "$match" ]] || continue
                     local match_abs
-                    match_abs=$(cd "$match" && pwd)
+                    match_abs=$(get_absolute_path "$match")
                     # Don't match the broken path itself, deduplicate
                     if [[ "$match_abs" != "$bp" ]] && ! _list_has "$match_seen" "$match_abs"; then
                         matches="${matches}${matches:+$'\n'}${match_abs}"
@@ -2084,7 +2171,7 @@ execute_fix_auto() {
                 execute_fix_explicit "$bp" "$single_match"
                 ((fixed++)) || true
             else
-                read -p "    Fix $bp → $single_match? [y/N] " -n 1 -r
+                prompt_read "    Fix $bp → $single_match? [y/N] " -n 1 -r
                 echo ""
                 if [[ $REPLY =~ ^[Yy]$ ]]; then
                     execute_fix_explicit "$bp" "$single_match"
@@ -2100,7 +2187,7 @@ execute_fix_auto() {
                 ((i++)) || true
             done <<< "$matches"
             if [[ "$DRY_RUN" != true && "$FORCE" != true ]]; then
-                read -p "    Select match (1-$match_count, or Enter to skip): " -r
+                prompt_read "    Select match (1-$match_count, or Enter to skip): " -r
                 if [[ -n "$REPLY" ]]; then
                     local selected
                     selected=$(echo "$matches" | sed -n "${REPLY}p")
@@ -2159,10 +2246,19 @@ main() {
         exit 0
     fi
     parse_args "$@"
+    if [[ "$PATH_ENCODING" == "windows" ]]; then
+        # Normalize CLAUDE_DIR etc for consistent display.
+        CLAUDE_DIR=$(get_absolute_path "$CLAUDE_DIR")
+        PROJECTS_DIR="$CLAUDE_DIR/projects"
+        HISTORY_FILE="$CLAUDE_DIR/history.jsonl"
+    fi
     validate
     show_preview
     confirm
     execute
 }
 
-main "$@"
+# Allow sourcing file without running main, for testing flexibility
+if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
+    main "$@"
+fi

--- a/test.sh
+++ b/test.sh
@@ -22,6 +22,12 @@ MOCK_CLAUDE_DIR=""
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 SCRIPT="$SCRIPT_DIR/clamp"
 
+# Real $HOME captured at script load (each test overrides HOME to its sandbox).
+ORIGINAL_HOME="$HOME"
+
+# Source clamp so tests can call its helpers; sourceability guard skips main().
+source "$SCRIPT"
+
 # Test counters
 TESTS_PASSED=0
 TESTS_FAILED=0
@@ -48,7 +54,9 @@ log_skip() {
 
 # Setup test environment
 setup_test_env() {
-    TEST_DIR=$(mktemp -d)
+    # Sandbox under $HOME, not /tmp.
+    # (MSYS auto-aliases /tmp cd-paths to forward-slash format).
+    TEST_DIR=$(TMPDIR="$ORIGINAL_HOME" mktemp -d -t clamp-test.XXXXXX)
     MOCK_CLAUDE_DIR="$TEST_DIR/.claude"
     mkdir -p "$MOCK_CLAUDE_DIR/projects"
     touch "$MOCK_CLAUDE_DIR/history.jsonl"
@@ -86,6 +94,33 @@ create_mock_project() {
 
     # Add entry to history.jsonl
     echo "{\"project\":\"$abs_path\",\"session\":\"session1\"}" >> "$MOCK_CLAUDE_DIR/history.jsonl"
+}
+
+# create_mock_project, adjusted for Windows
+# (embeds a path reference in session JSONL for rewrite testing)
+create_mock_windows_project() {
+    local project_path="$1"
+
+    mkdir -p "$project_path"
+    mkdir -p "$project_path/.claude"
+    echo "# Test Project" > "$project_path/README.md"
+    echo "test content" > "$project_path/.claude/settings.json"
+
+    local saved_encoding="$PATH_ENCODING"
+    PATH_ENCODING="windows"
+    local win_abs win_encoded win_hist
+    win_abs=$(get_absolute_path "$project_path")
+    win_encoded=$(encode_path "$win_abs")
+    win_hist=$(to_history_form "$win_abs")
+    PATH_ENCODING="$saved_encoding"
+
+    mkdir -p "$MOCK_CLAUDE_DIR/projects/$win_encoded"
+    echo "{\"type\":\"session\",\"cwd\":\"$win_hist\",\"data\":\"test\"}" \
+        > "$MOCK_CLAUDE_DIR/projects/$win_encoded/session1.jsonl"
+
+    # Add entry to history.jsonl with Windows-form path
+    echo "{\"project\":\"$win_hist\",\"session\":\"session1\"}" \
+        >> "$MOCK_CLAUDE_DIR/history.jsonl"
 }
 
 # Assert file exists
@@ -143,6 +178,19 @@ assert_not_contains() {
     local pattern="$2"
     local msg="${3:-File should not contain: $pattern}"
     if ! grep -qF -- "$pattern" "$file" 2>/dev/null; then
+        return 0
+    else
+        echo "  Assertion failed: $msg"
+        return 1
+    fi
+}
+
+# Assert two strings are equal
+assert_eq() {
+    local actual="$1"
+    local expected="$2"
+    local msg="${3:-Expected [$expected] but got [$actual]}"
+    if [[ "$actual" == "$expected" ]]; then
         return 0
     else
         echo "  Assertion failed: $msg"
@@ -303,6 +351,12 @@ test_symlink_source() {
 
     # Create symlink to it
     ln -s "$TEST_DIR/real-project" "$TEST_DIR/link-project"
+
+    # Skip if FS lacks real symlinks (MSYS without admin: `ln -s` makes a copy).
+    if [[ ! -L "$TEST_DIR/link-project" ]]; then
+        log_skip "Filesystem doesn't support symlinks (e.g. MSYS without admin), skipping"
+        return 0
+    fi
 
     # Move the symlink (should warn but proceed)
     local output
@@ -799,6 +853,330 @@ test_case_insensitive_path() {
 }
 
 # ============================================================================
+# WINDOWS PATH HANDLING - HELPER TESTS
+# ============================================================================
+
+test_encode_path_posix_basic() {
+    PATH_ENCODING="posix"
+    assert_eq "$(encode_path /home/me/foo)" "-home-me-foo"
+}
+
+test_encode_path_windows_git_bash_form() {
+    PATH_ENCODING="windows"
+    assert_eq "$(encode_path /d/projects/foo)" "D--projects-foo"
+}
+
+test_encode_path_windows_forward_slash() {
+    PATH_ENCODING="windows"
+    assert_eq "$(encode_path D:/projects/foo)" "D--projects-foo"
+}
+
+test_encode_path_windows_backslash() {
+    PATH_ENCODING="windows"
+    assert_eq "$(encode_path 'D:\projects\foo')" "D--projects-foo"
+}
+
+test_encode_path_windows_lowercase_drive() {
+    PATH_ENCODING="windows"
+    assert_eq "$(encode_path /c/users/me)" "C--users-me"
+}
+
+test_encode_path_windows_deep_multi_segment() {
+    PATH_ENCODING="windows"
+    assert_eq "$(encode_path /d/dev/example/some-deep-project)" \
+        "D--dev-example-some-deep-project"
+}
+
+test_encode_path_hyphen_collision_documented() {
+    # Lossy encoding: different paths can produce the same encoded form.
+    PATH_ENCODING="windows"
+    local a b
+    a=$(encode_path 'D:/my-cool-project')
+    b=$(encode_path 'D:/my/cool/project')
+    assert_eq "$a" "$b" "Both paths should encode identically (documented collision)"
+}
+
+test_to_history_form_posix_identity() {
+    PATH_ENCODING="posix"
+    assert_eq "$(to_history_form /home/me/foo)" "/home/me/foo"
+}
+
+test_to_history_form_windows() {
+    PATH_ENCODING="windows"
+    assert_eq "$(to_history_form 'D:/projects/foo')" 'D:\\projects\\foo'
+}
+
+test_to_history_form_windows_byte_exact() {
+    # Verify byte-for-byte that to_history_form produces 2 backslash bytes per separator.
+    PATH_ENCODING="windows"
+    local got_hex
+    got_hex=$(printf '%s' "$(to_history_form 'D:/projects/foo')" | xxd -p)
+    # Expected: D:\\projects\\foo as raw bytes — 5c5c per separator
+    assert_eq "$got_hex" "443a5c5c70726f6a656374735c5c666f6f"
+}
+
+test_from_history_form_posix_identity() {
+    PATH_ENCODING="posix"
+    assert_eq "$(from_history_form /home/me/foo)" "/home/me/foo"
+}
+
+test_from_history_form_windows() {
+    PATH_ENCODING="windows"
+    assert_eq "$(from_history_form 'D:\\projects\\foo')" "D:/projects/foo"
+}
+
+test_from_history_form_windows_byte_exact() {
+    PATH_ENCODING="windows"
+    local got_hex
+    got_hex=$(printf '%s' "$(from_history_form 'D:\\projects\\foo')" | xxd -p)
+    # Expected: D:/projects/foo as raw bytes — 2f per separator
+    assert_eq "$got_hex" "443a2f70726f6a656374732f666f6f"
+}
+
+test_to_from_roundtrip_basic() {
+    PATH_ENCODING="windows"
+    local sample="D:/projects/foo"
+    assert_eq "$(from_history_form "$(to_history_form "$sample")")" "$sample"
+}
+
+test_to_from_roundtrip_non_ascii() {
+    PATH_ENCODING="windows"
+    local sample='D:/Документы/foo'
+    assert_eq "$(from_history_form "$(to_history_form "$sample")")" "$sample"
+}
+
+test_to_from_roundtrip_with_spaces() {
+    PATH_ENCODING="windows"
+    local sample='D:/My Projects/cool app'
+    assert_eq "$(from_history_form "$(to_history_form "$sample")")" "$sample"
+}
+
+test_to_from_roundtrip_with_parens() {
+    PATH_ENCODING="windows"
+    local sample='D:/foo (copy)/bar'
+    assert_eq "$(from_history_form "$(to_history_form "$sample")")" "$sample"
+}
+
+test_is_absolute_path_posix_relative_rejected() {
+    PATH_ENCODING="posix"
+    if is_absolute_path "rel/path"; then
+        echo "  rel/path should not be absolute"
+        return 1
+    fi
+}
+
+test_is_absolute_path_windows_forms_accepted() {
+    PATH_ENCODING="windows"
+    is_absolute_path "D:/foo"   || { echo "  D:/foo should be absolute"; return 1; }
+    is_absolute_path 'D:\foo'   || { echo "  D:\\foo should be absolute"; return 1; }
+    is_absolute_path "/d/foo"   || { echo "  /d/foo should be absolute"; return 1; }
+}
+
+test_encode_path_unc_documented() {
+    # UNC handling is out of scope; encoded form indistinguishable.
+    # Test pins this behavior as baseline for improvement.
+    PATH_ENCODING="windows"
+    local back fwd
+    back=$(encode_path '\\server\share\foo')
+    fwd=$(encode_path '//server/share/foo')
+    assert_eq "$back" "--server-share-foo"
+    assert_eq "$fwd"  "--server-share-foo"
+}
+
+# ============================================================================
+# WINDOWS MODE - INTEGRATION TESTS
+# ============================================================================
+
+test_win_list_with_real_projects() {
+    create_mock_windows_project "$TEST_DIR/proj-a"
+    create_mock_windows_project "$TEST_DIR/proj-b"
+
+    PATH_ENCODING="windows"
+    local proj_a_win proj_b_win
+    proj_a_win=$(get_absolute_path "$TEST_DIR/proj-a")
+    proj_b_win=$(get_absolute_path "$TEST_DIR/proj-b")
+
+    local output
+    output=$("$SCRIPT" --encoding windows --list 2>&1)
+
+    if ! echo "$output" | grep -qF -- "$proj_a_win"; then
+        echo "  Expected proj-a in Windows form in output"
+        echo "  Output: $output"
+        return 1
+    fi
+    if ! echo "$output" | grep -qF -- "$proj_b_win"; then
+        echo "  Expected proj-b in Windows form in output"
+        echo "  Output: $output"
+        return 1
+    fi
+    # User-facing output should be in filesystem form, not history form.
+    if echo "$output" | grep -qE '\\\\'; then
+        echo "  Output should not contain double-backslash JSON-escape form"
+        echo "  Output: $output"
+        return 1
+    fi
+}
+
+test_win_verify_broken() {
+    create_mock_windows_project "$TEST_DIR/broken-proj"
+
+    PATH_ENCODING="windows"
+    local proj_win
+    proj_win=$(get_absolute_path "$TEST_DIR/broken-proj")
+
+    rm -rf "$TEST_DIR/broken-proj"
+
+    local output
+    output=$("$SCRIPT" --encoding windows --verify 2>&1)
+
+    if ! echo "$output" | grep -qF -- "$proj_win"; then
+        echo "  Expected broken path (Windows form) in verify output"
+        echo "  Output: $output"
+        return 1
+    fi
+    if echo "$output" | grep -qE '\\\\'; then
+        echo "  Output should not contain double-backslash JSON-escape form"
+        echo "  Output: $output"
+        return 1
+    fi
+}
+
+test_win_move_basic() {
+    create_mock_windows_project "$TEST_DIR/source-proj"
+
+    PATH_ENCODING="windows"
+    local source_win dest_win source_encoded dest_encoded
+    source_win=$(get_absolute_path "$TEST_DIR/source-proj")
+    dest_win=$(get_absolute_path "$TEST_DIR/dest-proj")
+    source_encoded=$(encode_path "$source_win")
+    dest_encoded=$(encode_path "$dest_win")
+
+    "$SCRIPT" --encoding windows "$source_win" "$dest_win" -f
+
+    assert_not_exists "$TEST_DIR/source-proj"           "Source folder should be gone" || return 1
+    assert_dir_exists "$TEST_DIR/dest-proj"             "Destination folder should exist" || return 1
+    assert_not_exists "$MOCK_CLAUDE_DIR/projects/$source_encoded" \
+        "Old encoded session folder should be gone" || return 1
+    assert_dir_exists "$MOCK_CLAUDE_DIR/projects/$dest_encoded" \
+        "New encoded session folder should exist" || return 1
+
+    local source_hist dest_hist
+    source_hist=$(to_history_form "$source_win")
+    dest_hist=$(to_history_form "$dest_win")
+    assert_not_contains "$MOCK_CLAUDE_DIR/history.jsonl" "$source_hist" \
+        "History should not contain old path" || return 1
+    assert_contains "$MOCK_CLAUDE_DIR/history.jsonl" "$dest_hist" \
+        "History should contain new path" || return 1
+
+    # Session JSONL's embedded path reference should be updated too.
+    local jsonl="$MOCK_CLAUDE_DIR/projects/$dest_encoded/session1.jsonl"
+    assert_contains "$jsonl" "$dest_hist" \
+        "Session JSONL should contain new path" || return 1
+    assert_not_contains "$jsonl" "$source_hist" \
+        "Session JSONL should not contain old path" || return 1
+}
+
+test_win_fix_explicit() {
+    create_mock_windows_project "$TEST_DIR/old-loc"
+
+    PATH_ENCODING="windows"
+    local old_win
+    old_win=$(get_absolute_path "$TEST_DIR/old-loc")
+
+    # Move project outside of clamp (history.jsonl will reference missing path).
+    mkdir -p "$TEST_DIR/new-loc"
+    cp -R "$TEST_DIR/old-loc/." "$TEST_DIR/new-loc/"
+    rm -rf "$TEST_DIR/old-loc"
+
+    local new_win old_encoded new_encoded
+    new_win=$(get_absolute_path "$TEST_DIR/new-loc")
+    old_encoded=$(encode_path "$old_win")
+    new_encoded=$(encode_path "$new_win")
+
+    "$SCRIPT" --encoding windows --fix --from "$old_win" --to "$new_win" -f
+
+    assert_not_exists "$MOCK_CLAUDE_DIR/projects/$old_encoded" || return 1
+    assert_dir_exists "$MOCK_CLAUDE_DIR/projects/$new_encoded" || return 1
+
+    local new_hist old_hist
+    new_hist=$(to_history_form "$new_win")
+    old_hist=$(to_history_form "$old_win")
+    assert_contains "$MOCK_CLAUDE_DIR/history.jsonl" "$new_hist" || return 1
+    assert_not_contains "$MOCK_CLAUDE_DIR/history.jsonl" "$old_hist" || return 1
+
+    local jsonl="$MOCK_CLAUDE_DIR/projects/$new_encoded/session1.jsonl"
+    assert_contains "$jsonl" "$new_hist" \
+        "Session JSONL should contain new path" || return 1
+}
+
+test_win_fix_auto_find_no_posix_leak() {
+    create_mock_windows_project "$TEST_DIR/auto-proj"
+
+    PATH_ENCODING="windows"
+    local old_win
+    old_win=$(get_absolute_path "$TEST_DIR/auto-proj")
+
+    # Manual mv to a location find can discover (under $HOME = $TEST_DIR)
+    mkdir -p "$TEST_DIR/new-home"
+    mv "$TEST_DIR/auto-proj" "$TEST_DIR/new-home/auto-proj"
+
+    local new_win
+    new_win=$(get_absolute_path "$TEST_DIR/new-home/auto-proj")
+
+    "$SCRIPT" --encoding windows --fix -f
+
+    local new_hist
+    new_hist=$(to_history_form "$new_win")
+    assert_contains "$MOCK_CLAUDE_DIR/history.jsonl" "$new_hist" \
+        "History should contain new Windows-form path after auto-fix" || return 1
+
+    # Regression check: no POSIX-mounted /c/... leak in history.jsonl.
+    if grep -qE '"project":"/[a-z]/' "$MOCK_CLAUDE_DIR/history.jsonl"; then
+        echo "  history.jsonl contains a POSIX-mounted-form path"
+        echo "  Indicates cd && pwd POSIX-form leak regression"
+        cat "$MOCK_CLAUDE_DIR/history.jsonl"
+        return 1
+    fi
+}
+
+test_win_move_with_spaces() {
+    create_mock_windows_project "$TEST_DIR/my proj"
+
+    PATH_ENCODING="windows"
+    local source_win dest_win dest_encoded
+    source_win=$(get_absolute_path "$TEST_DIR/my proj")
+    dest_win=$(get_absolute_path "$TEST_DIR/new proj")
+    dest_encoded=$(encode_path "$dest_win")
+
+    "$SCRIPT" --encoding windows "$source_win" "$dest_win" -f
+
+    assert_not_exists "$TEST_DIR/my proj"           "Source with space should be gone" || return 1
+    assert_dir_exists "$TEST_DIR/new proj"          "Destination with space should exist" || return 1
+    assert_dir_exists "$MOCK_CLAUDE_DIR/projects/$dest_encoded" \
+        "New encoded session folder should exist" || return 1
+
+    local dest_hist
+    dest_hist=$(to_history_form "$dest_win")
+    assert_contains "$MOCK_CLAUDE_DIR/history.jsonl" "$dest_hist" \
+        "History should contain new Windows-form path (with spaces)" || return 1
+}
+
+test_encoding_flag_validation() {
+    if ! "$SCRIPT" --encoding posix --list > /dev/null 2>&1; then
+        echo "  --encoding posix should be accepted"
+        return 1
+    fi
+    if ! "$SCRIPT" --encoding windows --list > /dev/null 2>&1; then
+        echo "  --encoding windows should be accepted"
+        return 1
+    fi
+    assert_fails "Invalid --encoding value should be rejected" \
+        "$SCRIPT" --encoding invalid --list || return 1
+    assert_fails "--encoding with no argument should be rejected" \
+        "$SCRIPT" --encoding || return 1
+}
+
+# ============================================================================
 # MAIN
 # ============================================================================
 
@@ -854,6 +1232,35 @@ main() {
         test_prune_dry_run
         # case-sensitivity tests
         test_case_insensitive_path
+        # Windows path handling — helper tests
+        test_encode_path_posix_basic
+        test_encode_path_windows_git_bash_form
+        test_encode_path_windows_forward_slash
+        test_encode_path_windows_backslash
+        test_encode_path_windows_lowercase_drive
+        test_encode_path_windows_deep_multi_segment
+        test_encode_path_hyphen_collision_documented
+        test_to_history_form_posix_identity
+        test_to_history_form_windows
+        test_to_history_form_windows_byte_exact
+        test_from_history_form_posix_identity
+        test_from_history_form_windows
+        test_from_history_form_windows_byte_exact
+        test_to_from_roundtrip_basic
+        test_to_from_roundtrip_non_ascii
+        test_to_from_roundtrip_with_spaces
+        test_to_from_roundtrip_with_parens
+        test_is_absolute_path_posix_relative_rejected
+        test_is_absolute_path_windows_forms_accepted
+        test_encode_path_unc_documented
+        # Windows mode — integration tests
+        test_win_list_with_real_projects
+        test_win_verify_broken
+        test_win_move_basic
+        test_win_fix_explicit
+        test_win_fix_auto_find_no_posix_leak
+        test_win_move_with_spaces
+        test_encoding_flag_validation
     )
 
     # Run specific test or all tests


### PR DESCRIPTION
AI-generated; humanized over many passes.

Adds `--encoding windows` so clamp works under Git Bash / MSYS on Windows. All operations (move, remove, pack, unpack, list, verify, fix, prune, info) routed through path-form helpers; existing POSIX behavior unchanged.

Flag instead of auto-detect for slightly reduced review surface. Latter could easily land as follow-up, if desired.

Addressed:
- Closes #6 (clamp now correctly handles Windows-encoded folder names and history.jsonl path bytes).
- Closes #7 (--move, --fix, --unpack now recursively rewrite paths inside per-session transcript JSONLs).
- Two latent bugs surfaced and fixed: `((project_count++))` without `|| true` triggering `set -e` exit during --list; `read -p` inside `done <<< "$broken_paths"` heredoc consuming iteration data instead of from the terminal (all `read -p` calls now funnel through a `prompt_read` helper).
- test.sh extended: 27 net-new tests (20 helper-level for path encodings, 7 Windows-mode integration). Existing POSIX tests untouched, still pass.
- test_symlink_source now `log_skip`s on filesystems that don't support real symlinks (e.g. MSYS without admin), instead of failing.