### PR TITLE
feat: add release pipeline and multi-channel install support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,34 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  test:
+    name: Tests (${{ matrix.os }})
+    strategy:
+      matrix:
+        # macos-latest ships bash 3.2, which clamp must stay compatible with
+        os: [ubuntu-latest, macos-latest]
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v4
+      - name: Run test suite
+        run: ./test.sh
+
+  lint:
+    name: ShellCheck
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Syntax check
+        run: |
+          bash -n clamp
+          bash -n test.sh
+          bash -n install.sh
+          bash -n scripts/build-dist.sh
+          bash -n scripts/release.sh
+      - name: ShellCheck (error severity)
+        run: shellcheck --severity=error clamp test.sh install.sh scripts/*.sh

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,80 @@
+# Release pipeline for clamp.
+#
+# Trigger: push a tag matching v* (normally created by scripts/release.sh).
+#
+# What it does:
+#   1. Checks the tag matches VERSION inside the clamp script.
+#   2. Runs the test suite.
+#   3. Builds artifacts with scripts/build-dist.sh (tarball, raw script,
+#      .deb, Homebrew formula, PKGBUILD, checksums).
+#   4. Creates a GitHub release with all artifacts attached.
+#   5. If the HOMEBREW_TAP_TOKEN secret is set, commits the rendered
+#      formula to <owner>/homebrew-tap at Formula/clamp.rb.
+#
+# AUR publishing stays manual: download the PKGBUILD asset from the
+# release and push it to the AUR (see README).
+name: Release
+
+on:
+  push:
+    tags: ['v*']
+
+permissions:
+  contents: write
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    env:
+      TAP_TOKEN: ${{ secrets.HOMEBREW_TAP_TOKEN }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Verify tag matches script version
+        run: |
+          script_version=$(grep -m1 '^VERSION=' clamp | cut -d'"' -f2)
+          tag_version="${GITHUB_REF_NAME#v}"
+          if [ "$script_version" != "$tag_version" ]; then
+            echo "Tag $GITHUB_REF_NAME does not match VERSION=$script_version in clamp" >&2
+            exit 1
+          fi
+
+      - name: Run test suite
+        run: ./test.sh
+
+      - name: Build artifacts
+        env:
+          CLAMP_REPO: ${{ github.repository }}
+        run: ./scripts/build-dist.sh
+
+      - name: Create GitHub release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh release create "$GITHUB_REF_NAME" \
+            --title "clamp $GITHUB_REF_NAME" \
+            --generate-notes \
+            dist/clamp \
+            dist/clamp-*.tar.gz \
+            dist/clamp_*_all.deb \
+            dist/clamp.rb \
+            dist/PKGBUILD \
+            dist/checksums.txt
+
+      - name: Publish formula to Homebrew tap
+        if: env.TAP_TOKEN != ''
+        env:
+          GH_TOKEN: ${{ env.TAP_TOKEN }}
+        run: |
+          owner="${GITHUB_REPOSITORY%%/*}"
+          tap_repo="$owner/homebrew-tap"
+          # Existing file sha is required by the contents API for updates
+          existing_sha=$(gh api "repos/$tap_repo/contents/Formula/clamp.rb" \
+            --jq .sha 2>/dev/null || true)
+          args=(-f message="chore: update clamp to $GITHUB_REF_NAME"
+                -f content="$(base64 -w0 dist/clamp.rb)")
+          if [ -n "$existing_sha" ]; then
+            args+=(-f sha="$existing_sha")
+          fi
+          gh api --method PUT "repos/$tap_repo/contents/Formula/clamp.rb" "${args[@]}"
+          echo "Formula pushed to $tap_repo"

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,9 @@
 # Claude Code local settings
 .claude/
 
+# Release artifacts
+dist/
+
 # Debug logs
 *.log
 firebase-debug.log

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -12,6 +12,10 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 The encoded path format converts `/path/to/dir` to `-path-to-dir`.
 
+## Releasing
+
+`VERSION="..."` inside the `clamp` script is the single source of truth. Run `scripts/release.sh X.Y.Z` to bump it, run tests, commit and tag. Pushing the `vX.Y.Z` tag triggers `.github/workflows/release.yml`, which builds artifacts via `scripts/build-dist.sh` (templates in `packaging/`) and creates the GitHub release. See the Releasing section in README.md.
+
 ## Testing
 
 Test locally by running with `--dry-run` flag:
@@ -25,8 +29,8 @@ Test locally by running with `--dry-run` flag:
 - Implements atomic rollback via EXIT trap if any step fails
 - Handles macOS vs Linux `sed -i` differences
 - Path resolution works for both existing and non-existing destination paths
-- Must be compatible with bash 3.2 (macOS default) — no associative arrays
-- Encoded path format is lossy (can't decode back) — use history.jsonl as source of truth
+- Must be compatible with bash 3.2 (macOS default), so no associative arrays
+- Encoded path format is lossy (can't decode back), use history.jsonl as source of truth
 - `_list_has` uses `grep -qFx --` (note `--` to handle values starting with `-`)
 
 ## Migration Sequence

--- a/README.md
+++ b/README.md
@@ -3,47 +3,85 @@
 **CL**aude **A**I **M**ove **P**roject
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
-[![Platform: macOS | Linux](https://img.shields.io/badge/Platform-macOS%20%7C%20Linux-blue.svg)](https://github.com/wsagency/claude-move-project#supported-platforms)
+[![Platform: macOS | Linux](https://img.shields.io/badge/Platform-macOS%20%7C%20Linux-blue.svg)](https://github.com/brunos3d/claude-move-project#supported-platforms)
+[![CI](https://github.com/brunos3d/claude-move-project/actions/workflows/ci.yml/badge.svg)](https://github.com/brunos3d/claude-move-project/actions/workflows/ci.yml)
 
 A bash utility that moves Claude Code projects while preserving all session history and settings.
 
 ## Features
 
-- 📦 **Move** project folders to new locations
-- 📂 **Move here** (`--here`) — move a project into the current directory
-- 🔧 **Fix** (`--fix`) — repair broken references after manual `mv`
-- 📋 **List** (`--list`) — show all Claude projects with status
-- ✅ **Verify** (`--verify`) — health check for project references
-- 🧹 **Prune** (`--prune`) — remove orphaned session folders
-- ℹ️ **Info** (`--info`) — detailed info about a single project
-- 🗑️ **Remove** projects and all associated session data (`--remove`)
-- 📤 **Pack** projects into portable `.claudepack` archives (`--pack`)
-- 📥 **Unpack** archives with automatic path rewriting (`--unpack`)
-- 🗂️ Auto-create parent directories with `-p`/`--parents`
-- 🔄 Automatically migrates session history from `~/.claude/projects/`
-- 📝 Updates all path references in `~/.claude/history.jsonl`
-- 🛡️ Atomic rollback if any step fails
-- 👀 Dry-run mode to preview changes before execution
+- **Move** project folders to new locations
+- **Move here** (`--here`): move a project into the current directory
+- **Fix** (`--fix`): repair broken references after manual `mv`
+- **List** (`--list`): show all Claude projects with status
+- **Verify** (`--verify`): health check for project references
+- **Prune** (`--prune`): remove orphaned session folders
+- **Info** (`--info`): detailed info about a single project
+- **Remove** projects and all associated session data (`--remove`)
+- **Pack** projects into portable `.claudepack` archives (`--pack`)
+- **Unpack** archives with automatic path rewriting (`--unpack`)
+- Auto-create parent directories with `-p`/`--parents`
+- Automatically migrates session history from `~/.claude/projects/`
+- Updates all path references in `~/.claude/history.jsonl`
+- Atomic rollback if any step fails
+- Dry-run mode to preview changes before execution
 
 ## Installation
+
+### Quick install (curl)
+
+Downloads the latest release, verifies its SHA-256 checksum and installs to `/usr/local/bin` (or `~/.local/bin` if that is not writable):
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/brunos3d/claude-move-project/main/install.sh | bash
+```
+
+Options via environment variables:
+
+```bash
+# Pin a specific version
+CLAMP_VERSION=1.4.1 curl -fsSL https://raw.githubusercontent.com/brunos3d/claude-move-project/main/install.sh | bash
+
+# Choose the install directory
+CLAMP_BIN_DIR=~/.local/bin curl -fsSL https://raw.githubusercontent.com/brunos3d/claude-move-project/main/install.sh | bash
+```
+
+To update, run the same command again. To uninstall, delete the `clamp` binary from the install directory.
 
 ### Homebrew (macOS/Linux)
 
 ```bash
-brew install wsagency/tap/clamp
+brew install brunos3d/tap/clamp
 ```
+
+Update with `brew upgrade clamp`. The tap is refreshed automatically on every release (see [Releasing](#releasing)).
+
+### AUR (Arch Linux)
+
+```bash
+# with an AUR helper
+yay -S clamp
+```
+
+Alternatively, download the `PKGBUILD` asset from the [latest release](https://github.com/brunos3d/claude-move-project/releases/latest) and run `makepkg -si`.
+
+### Debian/Ubuntu
+
+Each release ships a `.deb` package:
+
+```bash
+curl -fsSLO https://github.com/brunos3d/claude-move-project/releases/latest/download/clamp_1.4.1_all.deb
+sudo apt install ./clamp_1.4.1_all.deb
+```
+
+Replace the version with the one shown on the [releases page](https://github.com/brunos3d/claude-move-project/releases/latest). There is no apt repository; update by installing the newer `.deb`.
 
 ### Manual
 
 ```bash
-git clone https://github.com/wsagency/claude-move-project.git
+git clone https://github.com/brunos3d/claude-move-project.git
 cd claude-move-project
 chmod +x clamp
-```
-
-Optionally, add to your PATH:
-
-```bash
 sudo ln -s "$(pwd)/clamp" /usr/local/bin/clamp
 ```
 
@@ -173,7 +211,7 @@ clamp ./my-app ~/projects
 | `-h, --help` | Show help message |
 | `--version` | Show version |
 
-## 🔍 How It Works
+## How It Works
 
 Claude Code stores project data in three locations:
 
@@ -183,7 +221,7 @@ Claude Code stores project data in three locations:
 
 This script handles all three, ensuring your session history follows your project.
 
-### 🔄 Migration Sequence
+### Migration Sequence
 
 1. Backup `history.jsonl`
 2. Move project folder to destination
@@ -192,7 +230,7 @@ This script handles all three, ensuring your session history follows your projec
 
 If any step fails, all changes are automatically rolled back.
 
-### 🔧 Fix Operation
+### Fix Operation
 
 The most common scenario: you already moved a folder with `mv` and Claude sessions broke.
 
@@ -207,7 +245,7 @@ clamp --fix ~/new/location/my-project
 clamp --fix --from ~/old/path --to ~/new/path
 ```
 
-### 📦 Archive Format (.claudepack)
+### Archive Format (.claudepack)
 
 The `--pack` command creates a tar.gz archive with this structure:
 
@@ -221,7 +259,7 @@ project-name.claudepack
 
 When unpacking, paths are automatically rewritten to match the new destination.
 
-## 🧪 Testing
+## Testing
 
 Run the test suite to verify the script works correctly:
 
@@ -250,13 +288,81 @@ The test suite covers:
 - `--fix` (explicit paths, auto-detect, nothing broken)
 - `--prune` (orphaned folders, nothing to prune, dry-run)
 
-## 🖥️ Supported Platforms
+Continuous integration runs the suite on Ubuntu and macOS, plus `shellcheck`, on every push and pull request (`.github/workflows/ci.yml`). The macOS job matters because it runs bash 3.2, the oldest version clamp supports.
+
+## Releasing
+
+For maintainers. The whole flow is: bump, tag, push. GitHub Actions does the rest.
+
+```bash
+# 1. Bump the version, run tests, commit and tag (nothing is pushed yet)
+scripts/release.sh 1.5.0
+
+# 2. Publish
+git push origin main v1.5.0
+```
+
+The version in the `clamp` script (`VERSION="..."`) is the single source of truth. `scripts/release.sh` updates it, runs `./test.sh`, commits `chore: release v1.5.0` and creates the annotated tag `v1.5.0`.
+
+### What the Release workflow does
+
+Pushing a `v*` tag triggers `.github/workflows/release.yml`, which:
+
+1. Fails if the tag does not match `VERSION` inside the `clamp` script.
+2. Runs the test suite.
+3. Builds all artifacts with `scripts/build-dist.sh`.
+4. Creates a GitHub release with generated notes and these assets:
+
+| Asset | Purpose |
+|-------|---------|
+| `clamp` | Raw script, downloaded by `install.sh` |
+| `clamp-X.Y.Z.tar.gz` | Source tarball for Homebrew and the AUR |
+| `clamp_X.Y.Z_all.deb` | Debian/Ubuntu package |
+| `clamp.rb` | Homebrew formula pinned to this release |
+| `PKGBUILD` | AUR build file pinned to this release |
+| `checksums.txt` | SHA-256 checksums of all assets |
+
+5. If the `HOMEBREW_TAP_TOKEN` secret is set, commits `clamp.rb` to `<owner>/homebrew-tap` at `Formula/clamp.rb`.
+
+You can build the same artifacts locally with `scripts/build-dist.sh` (output goes to `dist/`, which is gitignored). The formula and PKGBUILD are rendered from the templates in `packaging/`.
+
+### One-time setup per channel
+
+- **curl install and .deb**: nothing to set up. They work as soon as the first release exists.
+- **Homebrew**: create a public repository named `homebrew-tap` under your account, then add a repository secret `HOMEBREW_TAP_TOKEN` here (a fine-grained personal access token with read/write contents permission on `homebrew-tap`). Users then run `brew install <owner>/tap/clamp`.
+- **AUR**: publishing is manual because it needs your personal AUR SSH key. After each release, download the `PKGBUILD` asset, then:
+
+  ```bash
+  git clone ssh://aur@aur.archlinux.org/clamp.git aur-clamp
+  cp PKGBUILD aur-clamp/
+  cd aur-clamp
+  makepkg --printsrcinfo > .SRCINFO
+  git add PKGBUILD .SRCINFO
+  git commit -m "Update to 1.5.0"
+  git push
+  ```
+
+  This can be automated later with an AUR deploy action and an SSH key secret.
+- **apt**: the `.deb` asset covers direct installs. A real apt repository (PPA or self-hosted) is out of scope for now.
+
+### For downstream package maintainers
+
+Every release provides stable URLs:
+
+```
+https://github.com/brunos3d/claude-move-project/releases/download/vX.Y.Z/clamp-X.Y.Z.tar.gz
+https://github.com/brunos3d/claude-move-project/releases/latest/download/checksums.txt
+```
+
+The tarball contains a `clamp-X.Y.Z/` directory with the `clamp` script, `LICENSE` and `README.md`. The `clamp.rb` and `PKGBUILD` assets already contain the correct version and SHA-256, so packaging for another distribution usually means adapting one of them.
+
+## Supported Platforms
 
 | Platform | Status |
 |----------|--------|
-| macOS | ✅ Fully supported |
-| Linux | ✅ Supported |
-| Windows | ⚠️ Via WSL or Git Bash |
+| macOS | Fully supported |
+| Linux | Supported |
+| Windows | Via WSL or Git Bash |
 
 ### Windows Users
 

--- a/README.md
+++ b/README.md
@@ -3,8 +3,8 @@
 **CL**aude **A**I **M**ove **P**roject
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
-[![Platform: macOS | Linux](https://img.shields.io/badge/Platform-macOS%20%7C%20Linux-blue.svg)](https://github.com/brunos3d/claude-move-project#supported-platforms)
-[![CI](https://github.com/brunos3d/claude-move-project/actions/workflows/ci.yml/badge.svg)](https://github.com/brunos3d/claude-move-project/actions/workflows/ci.yml)
+[![Platform: macOS | Linux](https://img.shields.io/badge/Platform-macOS%20%7C%20Linux-blue.svg)](https://github.com/wsagency/claude-move-project#supported-platforms)
+[![CI](https://github.com/wsagency/claude-move-project/actions/workflows/ci.yml/badge.svg)](https://github.com/wsagency/claude-move-project/actions/workflows/ci.yml)
 
 A bash utility that moves Claude Code projects while preserving all session history and settings.
 
@@ -33,17 +33,17 @@ A bash utility that moves Claude Code projects while preserving all session hist
 Downloads the latest release, verifies its SHA-256 checksum and installs to `/usr/local/bin` (or `~/.local/bin` if that is not writable):
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/brunos3d/claude-move-project/main/install.sh | bash
+curl -fsSL https://raw.githubusercontent.com/wsagency/claude-move-project/main/install.sh | bash
 ```
 
 Options via environment variables:
 
 ```bash
 # Pin a specific version
-CLAMP_VERSION=1.4.1 curl -fsSL https://raw.githubusercontent.com/brunos3d/claude-move-project/main/install.sh | bash
+CLAMP_VERSION=1.4.1 curl -fsSL https://raw.githubusercontent.com/wsagency/claude-move-project/main/install.sh | bash
 
 # Choose the install directory
-CLAMP_BIN_DIR=~/.local/bin curl -fsSL https://raw.githubusercontent.com/brunos3d/claude-move-project/main/install.sh | bash
+CLAMP_BIN_DIR=~/.local/bin curl -fsSL https://raw.githubusercontent.com/wsagency/claude-move-project/main/install.sh | bash
 ```
 
 To update, run the same command again. To uninstall, delete the `clamp` binary from the install directory.
@@ -51,7 +51,7 @@ To update, run the same command again. To uninstall, delete the `clamp` binary f
 ### Homebrew (macOS/Linux)
 
 ```bash
-brew install brunos3d/tap/clamp
+brew install wsagency/tap/clamp
 ```
 
 Update with `brew upgrade clamp`. The tap is refreshed automatically on every release (see [Releasing](#releasing)).
@@ -63,23 +63,23 @@ Update with `brew upgrade clamp`. The tap is refreshed automatically on every re
 yay -S clamp
 ```
 
-Alternatively, download the `PKGBUILD` asset from the [latest release](https://github.com/brunos3d/claude-move-project/releases/latest) and run `makepkg -si`.
+Alternatively, download the `PKGBUILD` asset from the [latest release](https://github.com/wsagency/claude-move-project/releases/latest) and run `makepkg -si`.
 
 ### Debian/Ubuntu
 
 Each release ships a `.deb` package:
 
 ```bash
-curl -fsSLO https://github.com/brunos3d/claude-move-project/releases/latest/download/clamp_1.4.1_all.deb
+curl -fsSLO https://github.com/wsagency/claude-move-project/releases/latest/download/clamp_1.4.1_all.deb
 sudo apt install ./clamp_1.4.1_all.deb
 ```
 
-Replace the version with the one shown on the [releases page](https://github.com/brunos3d/claude-move-project/releases/latest). There is no apt repository; update by installing the newer `.deb`.
+Replace the version with the one shown on the [releases page](https://github.com/wsagency/claude-move-project/releases/latest). There is no apt repository; update by installing the newer `.deb`.
 
 ### Manual
 
 ```bash
-git clone https://github.com/brunos3d/claude-move-project.git
+git clone https://github.com/wsagency/claude-move-project.git
 cd claude-move-project
 chmod +x clamp
 sudo ln -s "$(pwd)/clamp" /usr/local/bin/clamp
@@ -329,7 +329,7 @@ You can build the same artifacts locally with `scripts/build-dist.sh` (output go
 ### One-time setup per channel
 
 - **curl install and .deb**: nothing to set up. They work as soon as the first release exists.
-- **Homebrew**: create a public repository named `homebrew-tap` under your account, then add a repository secret `HOMEBREW_TAP_TOKEN` here (a fine-grained personal access token with read/write contents permission on `homebrew-tap`). Users then run `brew install <owner>/tap/clamp`.
+- **Homebrew**: the tap repository (`wsagency/homebrew-tap`) already exists. Add a repository secret `HOMEBREW_TAP_TOKEN` here (a fine-grained personal access token with read/write contents permission on `homebrew-tap`) and the workflow keeps `Formula/clamp.rb` up to date. Users run `brew install wsagency/tap/clamp`.
 - **AUR**: publishing is manual because it needs your personal AUR SSH key. After each release, download the `PKGBUILD` asset, then:
 
   ```bash
@@ -350,8 +350,8 @@ You can build the same artifacts locally with `scripts/build-dist.sh` (output go
 Every release provides stable URLs:
 
 ```
-https://github.com/brunos3d/claude-move-project/releases/download/vX.Y.Z/clamp-X.Y.Z.tar.gz
-https://github.com/brunos3d/claude-move-project/releases/latest/download/checksums.txt
+https://github.com/wsagency/claude-move-project/releases/download/vX.Y.Z/clamp-X.Y.Z.tar.gz
+https://github.com/wsagency/claude-move-project/releases/latest/download/checksums.txt
 ```
 
 The tarball contains a `clamp-X.Y.Z/` directory with the `clamp` script, `LICENSE` and `README.md`. The `clamp.rb` and `PKGBUILD` assets already contain the correct version and SHA-256, so packaging for another distribution usually means adapting one of them.

--- a/clamp
+++ b/clamp
@@ -1423,7 +1423,7 @@ execute_list() {
 
     local project_count=0
     while IFS= read -r _p; do
-        [[ -n "$_p" ]] && ((project_count++))
+        [[ -n "$_p" ]] && ((project_count++)) || true
     done <<< "$projects"
 
     if [[ "$JSON_OUTPUT" == true ]]; then

--- a/install.sh
+++ b/install.sh
@@ -3,18 +3,18 @@
 # install.sh - Install clamp from GitHub Releases.
 #
 # Usage:
-#   curl -fsSL https://raw.githubusercontent.com/brunos3d/claude-move-project/main/install.sh | bash
+#   curl -fsSL https://raw.githubusercontent.com/wsagency/claude-move-project/main/install.sh | bash
 #
 # Environment variables:
 #   CLAMP_VERSION  Version to install without the leading v (default: latest)
 #   CLAMP_BIN_DIR  Install directory (default: /usr/local/bin if writable,
 #                  otherwise ~/.local/bin)
 #   CLAMP_REPO     GitHub owner/repo to download from
-#                  (default: brunos3d/claude-move-project)
+#                  (default: wsagency/claude-move-project)
 
 set -euo pipefail
 
-REPO="${CLAMP_REPO:-brunos3d/claude-move-project}"
+REPO="${CLAMP_REPO:-wsagency/claude-move-project}"
 VERSION="${CLAMP_VERSION:-latest}"
 
 if [[ "$VERSION" == "latest" ]]; then

--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,66 @@
+#!/usr/bin/env bash
+#
+# install.sh - Install clamp from GitHub Releases.
+#
+# Usage:
+#   curl -fsSL https://raw.githubusercontent.com/brunos3d/claude-move-project/main/install.sh | bash
+#
+# Environment variables:
+#   CLAMP_VERSION  Version to install without the leading v (default: latest)
+#   CLAMP_BIN_DIR  Install directory (default: /usr/local/bin if writable,
+#                  otherwise ~/.local/bin)
+#   CLAMP_REPO     GitHub owner/repo to download from
+#                  (default: brunos3d/claude-move-project)
+
+set -euo pipefail
+
+REPO="${CLAMP_REPO:-brunos3d/claude-move-project}"
+VERSION="${CLAMP_VERSION:-latest}"
+
+if [[ "$VERSION" == "latest" ]]; then
+    BASE_URL="https://github.com/$REPO/releases/latest/download"
+else
+    BASE_URL="https://github.com/$REPO/releases/download/v$VERSION"
+fi
+
+TMP_DIR=$(mktemp -d)
+trap 'rm -rf "$TMP_DIR"' EXIT
+
+echo "Downloading clamp ($VERSION) from $REPO..."
+curl -fsSL "$BASE_URL/clamp" -o "$TMP_DIR/clamp"
+curl -fsSL "$BASE_URL/checksums.txt" -o "$TMP_DIR/checksums.txt"
+
+echo "Verifying checksum..."
+if command -v sha256sum >/dev/null 2>&1; then
+    actual=$(sha256sum "$TMP_DIR/clamp" | cut -d' ' -f1)
+else
+    actual=$(shasum -a 256 "$TMP_DIR/clamp" | cut -d' ' -f1)
+fi
+expected=$(grep -E '  clamp$' "$TMP_DIR/checksums.txt" | cut -d' ' -f1 || true)
+if [[ -z "$expected" || "$actual" != "$expected" ]]; then
+    echo "Error: checksum mismatch (expected: ${expected:-none}, got: $actual)" >&2
+    echo "Aborting install." >&2
+    exit 1
+fi
+
+if [[ -n "${CLAMP_BIN_DIR:-}" ]]; then
+    BIN_DIR="$CLAMP_BIN_DIR"
+    mkdir -p "$BIN_DIR"
+elif [[ -d /usr/local/bin && -w /usr/local/bin ]]; then
+    BIN_DIR="/usr/local/bin"
+else
+    BIN_DIR="$HOME/.local/bin"
+    mkdir -p "$BIN_DIR"
+fi
+
+install -m 0755 "$TMP_DIR/clamp" "$BIN_DIR/clamp"
+echo "Installed $("$BIN_DIR/clamp" --version) to $BIN_DIR/clamp"
+
+case ":$PATH:" in
+    *":$BIN_DIR:"*) ;;
+    *)
+        echo
+        echo "Note: $BIN_DIR is not in your PATH. Add this to your shell profile:"
+        echo "  export PATH=\"$BIN_DIR:\$PATH\""
+        ;;
+esac

--- a/packaging/PKGBUILD.tmpl
+++ b/packaging/PKGBUILD.tmpl
@@ -4,7 +4,7 @@
 #tmpl#   {{REPO}} GitHub owner/repo slug.
 #tmpl# Lines starting with #tmpl# are stripped from the rendered file.
 # Generate .SRCINFO with: makepkg --printsrcinfo > .SRCINFO
-# Maintainer: Bruno Silva <bruno3dcontato@gmail.com>
+# Maintainer: Kristijan Lukačin <kristijan@gmail.com>
 pkgname=clamp
 pkgver={{VERSION}}
 pkgrel=1

--- a/packaging/PKGBUILD.tmpl
+++ b/packaging/PKGBUILD.tmpl
@@ -1,0 +1,22 @@
+#tmpl# PKGBUILD template for the AUR.
+#tmpl# Rendered by scripts/build-dist.sh at release time. Placeholders:
+#tmpl#   {{VERSION}} release version, {{SHA256}} tarball checksum,
+#tmpl#   {{REPO}} GitHub owner/repo slug.
+#tmpl# Lines starting with #tmpl# are stripped from the rendered file.
+# Generate .SRCINFO with: makepkg --printsrcinfo > .SRCINFO
+# Maintainer: Bruno Silva <bruno3dcontato@gmail.com>
+pkgname=clamp
+pkgver={{VERSION}}
+pkgrel=1
+pkgdesc="Move Claude Code projects while preserving session history"
+arch=('any')
+url="https://github.com/{{REPO}}"
+license=('MIT')
+depends=('bash')
+source=("$pkgname-$pkgver.tar.gz::https://github.com/{{REPO}}/releases/download/v$pkgver/clamp-$pkgver.tar.gz")
+sha256sums=('{{SHA256}}')
+
+package() {
+  install -Dm755 "$srcdir/clamp-$pkgver/clamp" "$pkgdir/usr/bin/clamp"
+  install -Dm644 "$srcdir/clamp-$pkgver/LICENSE" "$pkgdir/usr/share/licenses/$pkgname/LICENSE"
+}

--- a/packaging/clamp.rb.tmpl
+++ b/packaging/clamp.rb.tmpl
@@ -1,0 +1,20 @@
+#tmpl# Homebrew formula template for clamp.
+#tmpl# Rendered by scripts/build-dist.sh at release time. Placeholders:
+#tmpl#   {{VERSION}} release version, {{SHA256}} tarball checksum,
+#tmpl#   {{REPO}} GitHub owner/repo slug.
+#tmpl# Lines starting with #tmpl# are stripped from the rendered file.
+class Clamp < Formula
+  desc "Move Claude Code projects while preserving session history"
+  homepage "https://github.com/{{REPO}}"
+  url "https://github.com/{{REPO}}/releases/download/v{{VERSION}}/clamp-{{VERSION}}.tar.gz"
+  sha256 "{{SHA256}}"
+  license "MIT"
+
+  def install
+    bin.install "clamp"
+  end
+
+  test do
+    assert_match version.to_s, shell_output("#{bin}/clamp --version")
+  end
+end

--- a/scripts/build-dist.sh
+++ b/scripts/build-dist.sh
@@ -17,7 +17,7 @@
 
 set -euo pipefail
 
-REPO_SLUG="${CLAMP_REPO:-brunos3d/claude-move-project}"
+REPO_SLUG="${CLAMP_REPO:-wsagency/claude-move-project}"
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 DIST_DIR="$ROOT_DIR/dist"
 
@@ -79,7 +79,7 @@ Section: utils
 Priority: optional
 Architecture: all
 Depends: bash
-Maintainer: Bruno Silva <bruno3dcontato@gmail.com>
+Maintainer: Kristijan Lukačin <kristijan@gmail.com>
 Homepage: https://github.com/$REPO_SLUG
 Description: Move Claude Code projects while preserving session history
  clamp moves, fixes, lists, verifies, prunes and packs Claude Code

--- a/scripts/build-dist.sh
+++ b/scripts/build-dist.sh
@@ -1,0 +1,107 @@
+#!/usr/bin/env bash
+#
+# build-dist.sh - Build release artifacts for clamp into dist/
+#
+# Produces:
+#   dist/clamp-<version>.tar.gz   Source tarball (clamp, LICENSE, README.md)
+#   dist/clamp                    Raw script, used by install.sh
+#   dist/clamp_<version>_all.deb  Debian package (requires dpkg-deb)
+#   dist/clamp.rb                 Homebrew formula pinned to this release
+#   dist/PKGBUILD                 AUR package build file pinned to this release
+#   dist/checksums.txt            SHA-256 checksums of all artifacts
+#
+# Runs locally and in CI. Requires bash, tar and sha256sum (or shasum).
+# dpkg-deb is optional: the .deb is skipped with a warning when missing.
+#
+# Usage: scripts/build-dist.sh
+
+set -euo pipefail
+
+REPO_SLUG="${CLAMP_REPO:-brunos3d/claude-move-project}"
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+DIST_DIR="$ROOT_DIR/dist"
+
+VERSION=$(grep -m1 '^VERSION=' "$ROOT_DIR/clamp" | cut -d'"' -f2 || true)
+if [[ -z "$VERSION" ]]; then
+    echo "Error: could not read VERSION from clamp" >&2
+    exit 1
+fi
+
+sha256() {
+    if command -v sha256sum >/dev/null 2>&1; then
+        sha256sum "$1" | cut -d' ' -f1
+    else
+        shasum -a 256 "$1" | cut -d' ' -f1
+    fi
+}
+
+echo "Building clamp $VERSION artifacts in dist/"
+rm -rf "$DIST_DIR"
+mkdir -p "$DIST_DIR"
+
+# Source tarball with a conventional top-level directory
+STAGE="$DIST_DIR/clamp-$VERSION"
+mkdir -p "$STAGE"
+cp "$ROOT_DIR/clamp" "$ROOT_DIR/LICENSE" "$ROOT_DIR/README.md" "$STAGE/"
+chmod 755 "$STAGE/clamp"
+tar -czf "$DIST_DIR/clamp-$VERSION.tar.gz" -C "$DIST_DIR" "clamp-$VERSION"
+rm -rf "$STAGE"
+
+# Raw script for curl-based installs
+cp "$ROOT_DIR/clamp" "$DIST_DIR/clamp"
+chmod 755 "$DIST_DIR/clamp"
+
+TARBALL_SHA=$(sha256 "$DIST_DIR/clamp-$VERSION.tar.gz")
+
+# Render packaging templates ({{VERSION}}, {{SHA256}}, {{REPO}}),
+# dropping template-only comment lines marked with #tmpl#
+render() {
+    sed -e '/^#tmpl#/d' \
+        -e "s/{{VERSION}}/$VERSION/g" \
+        -e "s/{{SHA256}}/$TARBALL_SHA/g" \
+        -e "s|{{REPO}}|$REPO_SLUG|g" \
+        "$1" > "$2"
+}
+render "$ROOT_DIR/packaging/clamp.rb.tmpl" "$DIST_DIR/clamp.rb"
+render "$ROOT_DIR/packaging/PKGBUILD.tmpl" "$DIST_DIR/PKGBUILD"
+
+# Debian package
+if command -v dpkg-deb >/dev/null 2>&1; then
+    PKGROOT="$DIST_DIR/debroot"
+    mkdir -p "$PKGROOT/DEBIAN" "$PKGROOT/usr/bin" "$PKGROOT/usr/share/doc/clamp"
+    cp "$ROOT_DIR/clamp" "$PKGROOT/usr/bin/clamp"
+    chmod 755 "$PKGROOT/usr/bin/clamp"
+    cp "$ROOT_DIR/LICENSE" "$PKGROOT/usr/share/doc/clamp/copyright"
+    cat > "$PKGROOT/DEBIAN/control" <<EOF
+Package: clamp
+Version: $VERSION
+Section: utils
+Priority: optional
+Architecture: all
+Depends: bash
+Maintainer: Bruno Silva <bruno3dcontato@gmail.com>
+Homepage: https://github.com/$REPO_SLUG
+Description: Move Claude Code projects while preserving session history
+ clamp moves, fixes, lists, verifies, prunes and packs Claude Code
+ projects while keeping session history and settings intact.
+EOF
+    dpkg-deb --build --root-owner-group "$PKGROOT" "$DIST_DIR/clamp_${VERSION}_all.deb" >/dev/null
+    rm -rf "$PKGROOT"
+else
+    echo "Warning: dpkg-deb not found, skipping .deb build" >&2
+fi
+
+# Checksums for everything in dist/
+(
+    cd "$DIST_DIR"
+    files=(clamp "clamp-$VERSION.tar.gz" clamp.rb PKGBUILD)
+    [[ -f "clamp_${VERSION}_all.deb" ]] && files+=("clamp_${VERSION}_all.deb")
+    if command -v sha256sum >/dev/null 2>&1; then
+        sha256sum "${files[@]}" > checksums.txt
+    else
+        shasum -a 256 "${files[@]}" > checksums.txt
+    fi
+)
+
+echo "Done:"
+ls -l "$DIST_DIR"

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+#
+# release.sh - Cut a clamp release from a clean working tree.
+#
+# Bumps VERSION in the clamp script, runs the test suite, commits and
+# creates an annotated tag. Pushing is left to you so nothing publishes
+# by accident. The Release GitHub Action takes over once the tag lands
+# on GitHub.
+#
+# Usage: scripts/release.sh <version>
+# Example: scripts/release.sh 1.5.0
+
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT_DIR"
+
+NEW_VERSION="${1:-}"
+if [[ ! "$NEW_VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+    echo "Usage: scripts/release.sh <version>   (example: 1.5.0)" >&2
+    exit 1
+fi
+
+if [[ -n "$(git status --porcelain)" ]]; then
+    echo "Error: working tree is not clean, commit or stash first" >&2
+    exit 1
+fi
+
+if git rev-parse "v$NEW_VERSION" >/dev/null 2>&1; then
+    echo "Error: tag v$NEW_VERSION already exists" >&2
+    exit 1
+fi
+
+CURRENT_VERSION=$(grep -m1 '^VERSION=' clamp | cut -d'"' -f2)
+echo "Bumping version: $CURRENT_VERSION -> $NEW_VERSION"
+
+# sed -i needs a suffix argument on macOS (BSD sed)
+sed -i.bak "s/^VERSION=\"$CURRENT_VERSION\"/VERSION=\"$NEW_VERSION\"/" clamp
+rm -f clamp.bak
+
+if [[ "$(grep -m1 '^VERSION=' clamp | cut -d'"' -f2)" != "$NEW_VERSION" ]]; then
+    echo "Error: failed to update VERSION in clamp" >&2
+    git checkout -- clamp
+    exit 1
+fi
+
+echo "Running test suite..."
+./test.sh
+
+git add clamp
+git commit -m "chore: release v$NEW_VERSION"
+git tag -a "v$NEW_VERSION" -m "clamp v$NEW_VERSION"
+
+BRANCH=$(git rev-parse --abbrev-ref HEAD)
+echo
+echo "Tagged v$NEW_VERSION. To publish, push the commit and the tag:"
+echo
+echo "  git push origin $BRANCH v$NEW_VERSION"
+echo
+echo "The Release workflow will build the artifacts and create the GitHub release."


### PR DESCRIPTION
## What changed

- New `Release` workflow (`.github/workflows/release.yml`): pushing a `vX.Y.Z` tag builds all distributable artifacts and creates a GitHub release.
- New `CI` workflow (`.github/workflows/ci.yml`): runs `test.sh` on Ubuntu and macOS (bash 3.2 coverage) plus `shellcheck` on every push and PR.
- `scripts/release.sh`: bumps `VERSION` in the `clamp` script, runs the tests, commits and tags. Nothing is pushed automatically.
- `scripts/build-dist.sh`: builds every artifact into `dist/`, both locally and in CI, so releases are reproducible.
- `install.sh`: curl-based installer that downloads the latest release, verifies the SHA-256 checksum and installs to `/usr/local/bin` or `~/.local/bin`.
- `packaging/clamp.rb.tmpl` and `packaging/PKGBUILD.tmpl`: templates rendered at build time with the release version and tarball checksum.
- README: new installation section (curl, Homebrew, AUR, deb, manual), a Releasing section for maintainers and a section for downstream package maintainers.
- Bug fix: `clamp --list` crashed under `set -e` because `((project_count++))` returns 1 when the counter is 0. It was the only unguarded increment in the script and made 3 tests fail. One line fix, the full suite now passes.

## Why

The repo has no tags, releases or automation yet, and the README advertises `brew install wsagency/tap/clamp` without a pipeline that keeps the tap current. A single-file bash CLI needs very little tooling, so this sticks to plain shell scripts and two small workflows instead of packaging frameworks.

## How the release flow works

```
scripts/release.sh 1.5.0        # bump VERSION, run tests, commit, tag
git push origin main v1.5.0     # publish
```

The tag push triggers the Release workflow, which:

1. Fails if the tag does not match `VERSION` inside the `clamp` script.
2. Runs the test suite.
3. Builds artifacts with `scripts/build-dist.sh`: raw `clamp` script, `clamp-X.Y.Z.tar.gz`, `clamp_X.Y.Z_all.deb`, rendered `clamp.rb`, rendered `PKGBUILD` and `checksums.txt`.
4. Creates the GitHub release with generated notes and all assets attached.
5. If a `HOMEBREW_TAP_TOKEN` secret exists, it commits the formula to `wsagency/homebrew-tap` as `Formula/clamp.rb` through the GitHub API (the tap owner is derived from the repository, so this also works on forks).

## What you need to do to enable each channel

- **curl install**: nothing. Works as soon as the first release exists.
- **Debian/Ubuntu**: nothing. The `.deb` is attached to every release; users install it with `sudo apt install ./clamp_X.Y.Z_all.deb`. A real apt repository would need a PPA or hosted repo later.
- **Homebrew**: `wsagency/homebrew-tap` already exists. Add a repository secret `HOMEBREW_TAP_TOKEN` (fine-grained PAT with read/write contents on `homebrew-tap`) and the workflow keeps the formula updated on every release.
- **AUR**: manual, since it needs a personal AUR SSH key. Register the `clamp` package on the AUR, then after each release download the `PKGBUILD` asset, run `makepkg --printsrcinfo > .SRCINFO` and push both. Exact commands are in the README. This can be automated later with an AUR deploy action.

The Maintainer fields in `packaging/PKGBUILD.tmpl` and the deb control (in `scripts/build-dist.sh`) are set to the repo author from the git history. Adjust them if you prefer a different contact.

To cut the first release from this pipeline: merge this PR, then run `scripts/release.sh 1.4.2` and push the tag.

## Verification

- Full test suite passes (35 passed, 0 failed, 1 skipped on case-sensitive filesystems).
- `shellcheck --severity=error` is clean on `clamp`, `test.sh`, `install.sh` and both scripts.
- `scripts/build-dist.sh` was run locally; the rendered formula and PKGBUILD were inspected.
- `install.sh` was tested end to end against a local HTTP server serving the built artifacts, including checksum verification.
