### PR TITLE
fix: migrate nested project histories on move and fix operations

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -34,7 +34,9 @@ Test locally by running with `--dry-run` flag:
 The script performs operations in this order (critical for rollback):
 1. Backup `history.jsonl`
 2. Move project folder
-3. Rename history folder in `~/.claude/projects/`
+3. Rename history folder in `~/.claude/projects/`, plus nested project
+   folders (sub-projects, worktrees) verified via the `cwd` field in
+   session files
 4. Update path references in `history.jsonl`
 
 Rollback reverses these steps if any operation fails.

--- a/README.md
+++ b/README.md
@@ -187,10 +187,21 @@ This script handles all three, ensuring your session history follows your projec
 
 1. Backup `history.jsonl`
 2. Move project folder to destination
-3. Rename history folder in `~/.claude/projects/`
-4. Update path references in `history.jsonl`
+3. Rename history folder in `~/.claude/projects/`, including folders of
+   nested projects (sub-projects and `.claude-worktrees` sessions)
+4. Update path references in `history.jsonl`, including nested paths
 
 If any step fails, all changes are automatically rolled back.
+
+### 📁 Nested Projects
+
+Claude Code treats every working directory as its own project. If you ran
+sessions from a subdirectory (for example `my-project/webapp`), those sessions
+live in a separate encoded folder in `~/.claude/projects/`. Both the move and
+fix operations detect these nested folders and migrate them along with the
+parent. Detection uses the `cwd` recorded in session files (with
+`history.jsonl` as fallback), so sibling projects that merely share a name
+prefix (like `my-project-api`) are left alone.
 
 ### 🔧 Fix Operation
 

--- a/clamp
+++ b/clamp
@@ -31,6 +31,10 @@ NC='\033[0m' # No Color
 BACKUP_FILE=""
 PROJECT_FOLDER_MOVED=false
 HISTORY_FOLDER_MOVED=false
+# Nested history folders renamed during a move, tracked for rollback
+# (parallel arrays, bash 3.2 has no associative arrays)
+CHILD_FOLDERS_OLD=()
+CHILD_FOLDERS_NEW=()
 SOURCE_ABS=""
 DEST_ABS=""
 OLD_ENCODED=""
@@ -210,6 +214,73 @@ log_verbose() {
     fi
 }
 
+# Print the working directory recorded in a history folder's session files.
+# Claude Code stores a "cwd" field in every session entry. Prints nothing
+# if no session file contains one.
+session_folder_cwd() {
+    local folder="$1"
+    local f cwd
+    for f in "$folder"/*.jsonl; do
+        if [[ ! -f "$f" ]]; then
+            continue
+        fi
+        cwd=$(grep -m1 -o '"cwd":"[^"]*"' "$f" 2>/dev/null | cut -d'"' -f4) || cwd=""
+        if [[ -n "$cwd" ]]; then
+            printf '%s\n' "$cwd"
+            return 0
+        fi
+    done
+    return 0
+}
+
+# Check whether an encoded history folder belongs to a project nested inside
+# the given path. The encoded format is lossy: a sibling like /a/foo-bar
+# shares the encoded prefix of /a/foo, so a name match alone is not enough.
+# Confirm against the cwd recorded in the folder's session files, falling
+# back to nested paths listed in history.jsonl.
+is_child_history_folder() {
+    local name="$1"
+    local source_abs="$2"
+    local cwd
+    cwd=$(session_folder_cwd "$PROJECTS_DIR/$name")
+    if [[ -n "$cwd" ]]; then
+        if [[ "$cwd" == "$source_abs"/* ]]; then
+            return 0
+        fi
+        return 1
+    fi
+
+    if [[ -f "$HISTORY_FILE" ]]; then
+        local project
+        while IFS= read -r project; do
+            if [[ "$project" != "$source_abs"/* ]]; then
+                continue
+            fi
+            if [[ "$(encode_path "$project")" == "$name" ]]; then
+                return 0
+            fi
+        done < <(grep -o '"project":"[^"]*"' "$HISTORY_FILE" 2>/dev/null | cut -d'"' -f4 | sort -u)
+    fi
+    return 1
+}
+
+# List encoded history folders of projects nested inside the given path
+# (sub-projects, worktrees). Prints one folder name per line.
+find_child_history_folders() {
+    local old_encoded="$1"
+    local source_abs="$2"
+    local folder name
+    for folder in "$PROJECTS_DIR/$old_encoded"-*; do
+        if [[ ! -d "$folder" ]]; then
+            continue
+        fi
+        name=$(basename "$folder")
+        if is_child_history_folder "$name" "$source_abs"; then
+            printf '%s\n' "$name"
+        fi
+    done
+}
+
 # Rollback on failure
 cleanup() {
     local exit_code=$?
@@ -222,7 +293,7 @@ cleanup() {
 
     # Only perform rollback if an operation actually started modifying state
     local has_state_to_rollback=false
-    if [[ -n "$BACKUP_FILE" || "$PROJECT_FOLDER_MOVED" == true || "$HISTORY_FOLDER_MOVED" == true || "$HISTORY_MODIFIED" == true ]]; then
+    if [[ -n "$BACKUP_FILE" || "$PROJECT_FOLDER_MOVED" == true || "$HISTORY_FOLDER_MOVED" == true || "$HISTORY_MODIFIED" == true || ${#CHILD_FOLDERS_NEW[@]} -gt 0 ]]; then
         has_state_to_rollback=true
     fi
 
@@ -238,6 +309,17 @@ cleanup() {
 
         case "$OPERATION" in
             move)
+                # Move nested history folders back
+                if [[ ${#CHILD_FOLDERS_NEW[@]} -gt 0 ]]; then
+                    local i
+                    for ((i = 0; i < ${#CHILD_FOLDERS_NEW[@]}; i++)); do
+                        if [[ -d "$PROJECTS_DIR/${CHILD_FOLDERS_NEW[$i]}" ]]; then
+                            mv "$PROJECTS_DIR/${CHILD_FOLDERS_NEW[$i]}" "$PROJECTS_DIR/${CHILD_FOLDERS_OLD[$i]}"
+                        fi
+                    done
+                    log_info "Restored nested history folders"
+                fi
+
                 # Move history folder back
                 if [[ "$HISTORY_FOLDER_MOVED" == true && -d "$PROJECTS_DIR/$NEW_ENCODED" ]]; then
                     mv "$PROJECTS_DIR/$NEW_ENCODED" "$PROJECTS_DIR/$OLD_ENCODED"
@@ -825,13 +907,29 @@ show_preview_move() {
     fi
     echo ""
 
+    # Nested project histories (sub-projects, worktrees)
+    local child_folders child
+    child_folders=$(find_child_history_folders "$OLD_ENCODED" "$SOURCE_ABS")
+    if [[ -n "$child_folders" ]]; then
+        echo "Nested Project Histories:"
+        while IFS= read -r child; do
+            echo "  $child/"
+            echo "    → $NEW_ENCODED${child#"$OLD_ENCODED"}/"
+        done <<< "$child_folders"
+        echo ""
+    fi
+
     # Count history.jsonl entries
     if [[ -f "$HISTORY_FILE" ]]; then
-        local entry_count
+        local entry_count nested_entry_count
         entry_count=$(grep -c -F -- "\"project\":\"$SOURCE_ABS\"" "$HISTORY_FILE" 2>/dev/null) || entry_count=0
+        nested_entry_count=$(grep -c -F -- "\"project\":\"$SOURCE_ABS/" "$HISTORY_FILE" 2>/dev/null) || nested_entry_count=0
         echo "History Index Updates:"
         echo "  File: $HISTORY_FILE"
         echo "  Entries to update: $entry_count reference(s)"
+        if [[ $nested_entry_count -gt 0 ]]; then
+            echo "  Nested entries to update: $nested_entry_count reference(s)"
+        fi
     else
         echo "History Index: (file not found)"
     fi
@@ -1068,6 +1166,24 @@ execute_move() {
         log_success "Renamed history folder"
     fi
 
+    # Step 3b: Rename history folders of projects nested inside the moved
+    # project (sub-projects, worktrees), which have their own encoded folders
+    local child new_child
+    while IFS= read -r child; do
+        if [[ -z "$child" ]]; then
+            continue
+        fi
+        new_child="$NEW_ENCODED${child#"$OLD_ENCODED"}"
+        if [[ -d "$PROJECTS_DIR/$new_child" ]]; then
+            log_warn "Nested history folder already exists, skipping: $new_child"
+            continue
+        fi
+        mv "$PROJECTS_DIR/$child" "$PROJECTS_DIR/$new_child"
+        CHILD_FOLDERS_OLD+=("$child")
+        CHILD_FOLDERS_NEW+=("$new_child")
+        log_success "Renamed nested history folder: $child"
+    done < <(find_child_history_folders "$OLD_ENCODED" "$SOURCE_ABS")
+
     # Step 4: Update history.jsonl
     if [[ -f "$HISTORY_FILE" ]]; then
         log_info "Updating history index..."
@@ -1079,11 +1195,17 @@ execute_move() {
         log_verbose "Escaped source for sed: $old_escaped"
         log_verbose "Escaped destination for sed: $new_escaped"
 
+        # Two patterns: exact match for the project itself, prefix match
+        # (trailing slash) for projects nested inside it
         # macOS sed requires '' after -i, Linux doesn't
         if [[ "$(uname)" == "Darwin" ]]; then
-            sed -i '' "s|\"project\":\"$old_escaped\"|\"project\":\"$new_escaped\"|g" "$HISTORY_FILE"
+            sed -i '' \
+                -e "s|\"project\":\"$old_escaped\"|\"project\":\"$new_escaped\"|g" \
+                -e "s|\"project\":\"$old_escaped/|\"project\":\"$new_escaped/|g" "$HISTORY_FILE"
         else
-            sed -i "s|\"project\":\"$old_escaped\"|\"project\":\"$new_escaped\"|g" "$HISTORY_FILE"
+            sed -i \
+                -e "s|\"project\":\"$old_escaped\"|\"project\":\"$new_escaped\"|g" \
+                -e "s|\"project\":\"$old_escaped/|\"project\":\"$new_escaped/|g" "$HISTORY_FILE"
         fi
         log_success "Updated history index"
     fi
@@ -1833,12 +1955,28 @@ execute_fix_explicit() {
         log_warn "No session folder found for either path"
     fi
 
-    # Check history entries
-    local entry_count=0
+    # Check session folders of nested projects (sub-projects, worktrees)
+    local child_folders child
+    child_folders=$(find_child_history_folders "$old_encoded" "$old_path")
+    if [[ -n "$child_folders" ]]; then
+        while IFS= read -r child; do
+            echo "Nested session folder: $PROJECTS_DIR/$child/"
+            echo "  → $PROJECTS_DIR/$new_encoded${child#"$old_encoded"}/"
+        done <<< "$child_folders"
+        changes=1
+    fi
+
+    # Check history entries (exact path plus nested paths)
+    local entry_count=0 nested_entry_count=0
     if [[ -f "$HISTORY_FILE" ]]; then
         entry_count=$(grep -c -F -- "\"project\":\"$old_path\"" "$HISTORY_FILE" 2>/dev/null) || entry_count=0
+        nested_entry_count=$(grep -c -F -- "\"project\":\"$old_path/" "$HISTORY_FILE" 2>/dev/null) || nested_entry_count=0
         if [[ $entry_count -gt 0 ]]; then
             echo "History entries to update: $entry_count"
+            changes=1
+        fi
+        if [[ $nested_entry_count -gt 0 ]]; then
+            echo "Nested history entries to update: $nested_entry_count"
             changes=1
         fi
     fi
@@ -1882,18 +2020,36 @@ execute_fix_explicit() {
         fi
     fi
 
-    # Update history.jsonl
-    if [[ -f "$HISTORY_FILE" && $entry_count -gt 0 ]]; then
+    # Rename nested session folders
+    if [[ -n "$child_folders" ]]; then
+        local new_child
+        while IFS= read -r child; do
+            new_child="$new_encoded${child#"$old_encoded"}"
+            if [[ -d "$PROJECTS_DIR/$new_child" ]]; then
+                log_warn "Nested session folder already exists, skipping: $new_child"
+                continue
+            fi
+            mv "$PROJECTS_DIR/$child" "$PROJECTS_DIR/$new_child"
+            log_success "Renamed nested session folder: $child"
+        done <<< "$child_folders"
+    fi
+
+    # Update history.jsonl (exact path plus nested paths)
+    if [[ -f "$HISTORY_FILE" && $((entry_count + nested_entry_count)) -gt 0 ]]; then
         local old_escaped new_escaped
         old_escaped=$(escape_for_sed "$old_path")
         new_escaped=$(escape_for_sed "$new_path")
 
         if [[ "$(uname)" == "Darwin" ]]; then
-            sed -i '' "s|\"project\":\"$old_escaped\"|\"project\":\"$new_escaped\"|g" "$HISTORY_FILE"
+            sed -i '' \
+                -e "s|\"project\":\"$old_escaped\"|\"project\":\"$new_escaped\"|g" \
+                -e "s|\"project\":\"$old_escaped/|\"project\":\"$new_escaped/|g" "$HISTORY_FILE"
         else
-            sed -i "s|\"project\":\"$old_escaped\"|\"project\":\"$new_escaped\"|g" "$HISTORY_FILE"
+            sed -i \
+                -e "s|\"project\":\"$old_escaped\"|\"project\":\"$new_escaped\"|g" \
+                -e "s|\"project\":\"$old_escaped/|\"project\":\"$new_escaped/|g" "$HISTORY_FILE"
         fi
-        log_success "Updated $entry_count history entries"
+        log_success "Updated $((entry_count + nested_entry_count)) history entries"
     fi
 
     echo ""

--- a/clamp
+++ b/clamp
@@ -35,6 +35,9 @@ HISTORY_FOLDER_MOVED=false
 # (parallel arrays, bash 3.2 has no associative arrays)
 CHILD_FOLDERS_OLD=()
 CHILD_FOLDERS_NEW=()
+# Entries moved between history folders during a merge, tracked for rollback
+MERGED_SRC=()
+MERGED_DST=()
 SOURCE_ABS=""
 DEST_ABS=""
 OLD_ENCODED=""
@@ -264,6 +267,37 @@ is_child_history_folder() {
     return 1
 }
 
+# Merge the contents of a history folder into one that already exists at
+# the destination name. A plain mv would nest the source folder inside the
+# destination, hiding every session from claude --resume. Session files are
+# named by UUID so collisions are rare; entries that do collide are kept at
+# the destination and left behind with a warning. Removes the source folder
+# once empty.
+merge_history_folder() {
+    local src="$1"
+    local dst="$2"
+    local entry name
+    log_info "Destination exists, merging contents: $(basename "$dst")"
+    for entry in "$src"/* "$src"/.[!.]* "$src"/..?*; do
+        if [[ ! -e "$entry" ]]; then
+            continue
+        fi
+        name=$(basename "$entry")
+        if [[ -e "$dst/$name" ]]; then
+            log_warn "Already exists at destination, left in place: $entry"
+            continue
+        fi
+        mv "$entry" "$dst/$name"
+        MERGED_SRC+=("$entry")
+        MERGED_DST+=("$dst/$name")
+    done
+    if rmdir "$src" 2>/dev/null; then
+        log_success "Merged history folder: $(basename "$src")"
+    else
+        log_warn "Source folder not empty after merge, kept: $src"
+    fi
+}
+
 # List encoded history folders of projects nested inside the given path
 # (sub-projects, worktrees). Prints one folder name per line.
 find_child_history_folders() {
@@ -293,7 +327,7 @@ cleanup() {
 
     # Only perform rollback if an operation actually started modifying state
     local has_state_to_rollback=false
-    if [[ -n "$BACKUP_FILE" || "$PROJECT_FOLDER_MOVED" == true || "$HISTORY_FOLDER_MOVED" == true || "$HISTORY_MODIFIED" == true || ${#CHILD_FOLDERS_NEW[@]} -gt 0 ]]; then
+    if [[ -n "$BACKUP_FILE" || "$PROJECT_FOLDER_MOVED" == true || "$HISTORY_FOLDER_MOVED" == true || "$HISTORY_MODIFIED" == true || ${#CHILD_FOLDERS_NEW[@]} -gt 0 || ${#MERGED_DST[@]} -gt 0 ]]; then
         has_state_to_rollback=true
     fi
 
@@ -309,6 +343,18 @@ cleanup() {
 
         case "$OPERATION" in
             move)
+                # Move merged session files back to their original folders
+                if [[ ${#MERGED_DST[@]} -gt 0 ]]; then
+                    local m
+                    for ((m = ${#MERGED_DST[@]} - 1; m >= 0; m--)); do
+                        if [[ -e "${MERGED_DST[$m]}" && ! -e "${MERGED_SRC[$m]}" ]]; then
+                            mkdir -p "$(dirname "${MERGED_SRC[$m]}")"
+                            mv "${MERGED_DST[$m]}" "${MERGED_SRC[$m]}"
+                        fi
+                    done
+                    log_info "Restored merged session files"
+                fi
+
                 # Move nested history folders back
                 if [[ ${#CHILD_FOLDERS_NEW[@]} -gt 0 ]]; then
                     local i
@@ -896,6 +942,9 @@ show_preview_move() {
     echo "History Migration:"
     echo "  From: $PROJECTS_DIR/$OLD_ENCODED/"
     echo "  To:   $PROJECTS_DIR/$NEW_ENCODED/"
+    if [[ -d "$PROJECTS_DIR/$OLD_ENCODED" && -d "$PROJECTS_DIR/$NEW_ENCODED" ]]; then
+        echo "  Note: destination folder exists, contents will be merged"
+    fi
 
     # Count session files
     if [[ -d "$PROJECTS_DIR/$OLD_ENCODED" ]]; then
@@ -1158,12 +1207,18 @@ execute_move() {
     PROJECT_FOLDER_MOVED=true
     log_success "Moved project to: $DEST_ABS"
 
-    # Step 3: Rename history folder
+    # Step 3: Rename history folder. If the destination folder already
+    # exists (claude was opened at the new location before the migration),
+    # merge into it instead of nesting the old folder inside
     if [[ -d "$PROJECTS_DIR/$OLD_ENCODED" ]]; then
         log_info "Renaming history folder..."
-        mv "$PROJECTS_DIR/$OLD_ENCODED" "$PROJECTS_DIR/$NEW_ENCODED"
-        HISTORY_FOLDER_MOVED=true
-        log_success "Renamed history folder"
+        if [[ -d "$PROJECTS_DIR/$NEW_ENCODED" ]]; then
+            merge_history_folder "$PROJECTS_DIR/$OLD_ENCODED" "$PROJECTS_DIR/$NEW_ENCODED"
+        else
+            mv "$PROJECTS_DIR/$OLD_ENCODED" "$PROJECTS_DIR/$NEW_ENCODED"
+            HISTORY_FOLDER_MOVED=true
+            log_success "Renamed history folder"
+        fi
     fi
 
     # Step 3b: Rename history folders of projects nested inside the moved
@@ -1175,7 +1230,7 @@ execute_move() {
         fi
         new_child="$NEW_ENCODED${child#"$OLD_ENCODED"}"
         if [[ -d "$PROJECTS_DIR/$new_child" ]]; then
-            log_warn "Nested history folder already exists, skipping: $new_child"
+            merge_history_folder "$PROJECTS_DIR/$child" "$PROJECTS_DIR/$new_child"
             continue
         fi
         mv "$PROJECTS_DIR/$child" "$PROJECTS_DIR/$new_child"
@@ -2010,23 +2065,23 @@ execute_fix_explicit() {
         log_success "Created backup: $BACKUP_FILE"
     fi
 
-    # Rename session folder
+    # Rename session folder, merging if the destination already exists
     if [[ -d "$PROJECTS_DIR/$old_encoded" ]]; then
         if [[ -d "$PROJECTS_DIR/$new_encoded" ]]; then
-            log_warn "New session folder already exists, skipping rename"
+            merge_history_folder "$PROJECTS_DIR/$old_encoded" "$PROJECTS_DIR/$new_encoded"
         else
             mv "$PROJECTS_DIR/$old_encoded" "$PROJECTS_DIR/$new_encoded"
             log_success "Renamed session folder"
         fi
     fi
 
-    # Rename nested session folders
+    # Rename nested session folders, merging if the destination exists
     if [[ -n "$child_folders" ]]; then
         local new_child
         while IFS= read -r child; do
             new_child="$new_encoded${child#"$old_encoded"}"
             if [[ -d "$PROJECTS_DIR/$new_child" ]]; then
-                log_warn "Nested session folder already exists, skipping: $new_child"
+                merge_history_folder "$PROJECTS_DIR/$child" "$PROJECTS_DIR/$new_child"
                 continue
             fi
             mv "$PROJECTS_DIR/$child" "$PROJECTS_DIR/$new_child"

--- a/clamp
+++ b/clamp
@@ -217,39 +217,51 @@ log_verbose() {
     fi
 }
 
-# Print the working directory recorded in a history folder's session files.
-# Claude Code stores a "cwd" field in every session entry. Prints nothing
-# if no session file contains one.
-session_folder_cwd() {
+# Scan a history folder's session files for recorded working directories.
+# Claude Code stores a "cwd" field in every session entry, and one file can
+# hold several distinct values when a session is resumed from different
+# directories. Returns 0 if any cwd lies inside the given path, 1 if cwd
+# values exist but none match, 2 if no session file records a cwd at all.
+folder_has_session_under() {
     local folder="$1"
-    local f cwd
+    local source_abs="$2"
+    local f cwd found_any=false
     for f in "$folder"/*.jsonl; do
         if [[ ! -f "$f" ]]; then
             continue
         fi
-        cwd=$(grep -m1 -o '"cwd":"[^"]*"' "$f" 2>/dev/null | cut -d'"' -f4) || cwd=""
-        if [[ -n "$cwd" ]]; then
-            printf '%s\n' "$cwd"
-            return 0
-        fi
+        while IFS= read -r cwd; do
+            if [[ -z "$cwd" ]]; then
+                continue
+            fi
+            found_any=true
+            if [[ "$cwd" == "$source_abs"/* ]]; then
+                return 0
+            fi
+        done < <(grep -o '"cwd":"[^"]*"' "$f" 2>/dev/null | cut -d'"' -f4 | sort -u)
     done
-    return 0
+    if [[ "$found_any" == true ]]; then
+        return 1
+    fi
+    return 2
 }
 
 # Check whether an encoded history folder belongs to a project nested inside
 # the given path. The encoded format is lossy: a sibling like /a/foo-bar
 # shares the encoded prefix of /a/foo, so a name match alone is not enough.
-# Confirm against the cwd recorded in the folder's session files, falling
-# back to nested paths listed in history.jsonl.
+# Confirm against the cwd values recorded in the folder's session files,
+# falling back to nested paths listed in history.jsonl only when the folder
+# records no cwd at all (a folder with cwds that all point elsewhere is a
+# sibling and must be left alone).
 is_child_history_folder() {
     local name="$1"
     local source_abs="$2"
-    local cwd
-    cwd=$(session_folder_cwd "$PROJECTS_DIR/$name")
-    if [[ -n "$cwd" ]]; then
-        if [[ "$cwd" == "$source_abs"/* ]]; then
-            return 0
-        fi
+    local cwd_result=0
+    folder_has_session_under "$PROJECTS_DIR/$name" "$source_abs" || cwd_result=$?
+    if [[ $cwd_result -eq 0 ]]; then
+        return 0
+    fi
+    if [[ $cwd_result -eq 1 ]]; then
         return 1
     fi
 

--- a/test.sh
+++ b/test.sh
@@ -88,6 +88,17 @@ create_mock_project() {
     echo "{\"project\":\"$abs_path\",\"session\":\"session1\"}" >> "$MOCK_CLAUDE_DIR/history.jsonl"
 }
 
+# Create a history folder with a session file that records its cwd,
+# plus a matching history.jsonl entry (mirrors real Claude Code data)
+create_mock_history_folder() {
+    local encoded="$1"
+    local cwd="$2"
+
+    mkdir -p "$MOCK_CLAUDE_DIR/projects/$encoded"
+    echo "{\"type\":\"session\",\"cwd\":\"$cwd\",\"data\":\"test\"}" > "$MOCK_CLAUDE_DIR/projects/$encoded/session1.jsonl"
+    echo "{\"project\":\"$cwd\",\"session\":\"session1\"}" >> "$MOCK_CLAUDE_DIR/history.jsonl"
+}
+
 # Assert file exists
 assert_exists() {
     local path="$1"
@@ -799,6 +810,122 @@ test_case_insensitive_path() {
 }
 
 # ============================================================================
+# NESTED PROJECT HISTORY TESTS
+# ============================================================================
+
+test_move_nested_project_history() {
+    # Parent project with a nested Claude project inside it
+    create_mock_project "$TEST_DIR/parent"
+    local source_abs="$TEST_DIR/parent"
+    local dest_abs="$TEST_DIR/dest-project"
+
+    mkdir -p "$source_abs/webapp"
+    local child_encoded="${source_abs//\//-}-webapp"
+    create_mock_history_folder "$child_encoded" "$source_abs/webapp"
+
+    "$SCRIPT" "$source_abs" "$dest_abs" -f
+
+    local new_child_encoded="${dest_abs//\//-}-webapp"
+    assert_not_exists "$MOCK_CLAUDE_DIR/projects/$child_encoded" \
+        "Old nested history folder should be gone" || return 1
+    assert_dir_exists "$MOCK_CLAUDE_DIR/projects/$new_child_encoded" \
+        "Nested history folder should be renamed" || return 1
+    assert_exists "$MOCK_CLAUDE_DIR/projects/$new_child_encoded/session1.jsonl" \
+        "Nested session file should survive the rename" || return 1
+    assert_not_contains "$MOCK_CLAUDE_DIR/history.jsonl" "$source_abs/webapp" \
+        "Old nested path should not be in history" || return 1
+    assert_contains "$MOCK_CLAUDE_DIR/history.jsonl" "$dest_abs/webapp" \
+        "New nested path should be in history" || return 1
+}
+
+test_move_nested_worktree_history() {
+    create_mock_project "$TEST_DIR/parent"
+    local source_abs="$TEST_DIR/parent"
+    local dest_abs="$TEST_DIR/dest-project"
+
+    # Claude Code encodes /parent/.claude-worktrees/feature-x with the dot
+    # collapsed to a dash, producing a double dash after the parent prefix
+    local wt_encoded="${source_abs//\//-}--claude-worktrees-feature-x"
+    create_mock_history_folder "$wt_encoded" "$source_abs/.claude-worktrees/feature-x"
+
+    "$SCRIPT" "$source_abs" "$dest_abs" -f
+
+    local new_wt_encoded="${dest_abs//\//-}--claude-worktrees-feature-x"
+    assert_not_exists "$MOCK_CLAUDE_DIR/projects/$wt_encoded" \
+        "Old worktree history folder should be gone" || return 1
+    assert_dir_exists "$MOCK_CLAUDE_DIR/projects/$new_wt_encoded" \
+        "Worktree history folder should be renamed" || return 1
+    assert_contains "$MOCK_CLAUDE_DIR/history.jsonl" "$dest_abs/.claude-worktrees/feature-x" \
+        "Worktree history entry should point to new path" || return 1
+}
+
+test_move_skips_lookalike_sibling() {
+    create_mock_project "$TEST_DIR/parent"
+    local source_abs="$TEST_DIR/parent"
+    local dest_abs="$TEST_DIR/dest-project"
+
+    # Sibling project whose encoded name shares the parent's encoded prefix
+    # (-...-parent-api starts with -...-parent-) but is not a child
+    mkdir -p "$TEST_DIR/parent-api"
+    local sibling_encoded="${TEST_DIR//\//-}-parent-api"
+    create_mock_history_folder "$sibling_encoded" "$TEST_DIR/parent-api"
+
+    "$SCRIPT" "$source_abs" "$dest_abs" -f
+
+    assert_dir_exists "$MOCK_CLAUDE_DIR/projects/$sibling_encoded" \
+        "Sibling history folder should be untouched" || return 1
+    assert_contains "$MOCK_CLAUDE_DIR/history.jsonl" "$TEST_DIR/parent-api" \
+        "Sibling history entry should be unchanged" || return 1
+}
+
+test_move_nested_dry_run() {
+    create_mock_project "$TEST_DIR/parent"
+    local source_abs="$TEST_DIR/parent"
+    local dest_abs="$TEST_DIR/dest-project"
+
+    mkdir -p "$source_abs/webapp"
+    local child_encoded="${source_abs//\//-}-webapp"
+    create_mock_history_folder "$child_encoded" "$source_abs/webapp"
+
+    local output
+    output=$("$SCRIPT" "$source_abs" "$dest_abs" --dry-run)
+
+    if ! echo "$output" | grep -qF -- "$child_encoded"; then
+        echo "  Assertion failed: dry-run preview should list the nested history folder"
+        return 1
+    fi
+    assert_dir_exists "$MOCK_CLAUDE_DIR/projects/$child_encoded" \
+        "Dry run must not rename the nested history folder" || return 1
+    assert_dir_exists "$source_abs" "Dry run must not move the project" || return 1
+}
+
+test_fix_nested_project_history() {
+    # Simulate a manual mv: project already at the new location,
+    # history data still under the old encoded names
+    local old_abs="$TEST_DIR/old-location"
+    local new_abs="$TEST_DIR/new-location"
+    mkdir -p "$new_abs/webapp"
+
+    local old_encoded="${old_abs//\//-}"
+    local old_child_encoded="${old_abs//\//-}-webapp"
+    create_mock_history_folder "$old_encoded" "$old_abs"
+    create_mock_history_folder "$old_child_encoded" "$old_abs/webapp"
+
+    "$SCRIPT" --fix --from "$old_abs" --to "$new_abs" -f
+
+    assert_dir_exists "$MOCK_CLAUDE_DIR/projects/${new_abs//\//-}" \
+        "Main history folder should be renamed" || return 1
+    assert_not_exists "$MOCK_CLAUDE_DIR/projects/$old_child_encoded" \
+        "Old nested history folder should be gone" || return 1
+    assert_dir_exists "$MOCK_CLAUDE_DIR/projects/${new_abs//\//-}-webapp" \
+        "Nested history folder should be renamed by --fix" || return 1
+    assert_contains "$MOCK_CLAUDE_DIR/history.jsonl" "$new_abs/webapp" \
+        "Nested history entry should point to new path" || return 1
+    assert_not_contains "$MOCK_CLAUDE_DIR/history.jsonl" "$old_abs/webapp" \
+        "Old nested path should not remain in history" || return 1
+}
+
+# ============================================================================
 # MAIN
 # ============================================================================
 
@@ -854,6 +981,12 @@ main() {
         test_prune_dry_run
         # case-sensitivity tests
         test_case_insensitive_path
+        # nested project history tests
+        test_move_nested_project_history
+        test_move_nested_worktree_history
+        test_move_skips_lookalike_sibling
+        test_move_nested_dry_run
+        test_fix_nested_project_history
     )
 
     # Run specific test or all tests

--- a/test.sh
+++ b/test.sh
@@ -925,6 +925,62 @@ test_fix_nested_project_history() {
         "Old nested path should not remain in history" || return 1
 }
 
+test_move_merges_existing_history_folder() {
+    # Destination history folder already exists (claude was opened at the
+    # new location before running clamp). A plain mv would nest the old
+    # folder inside it, hiding every session from --resume (issue #13).
+    create_mock_project "$TEST_DIR/parent"
+    local source_abs="$TEST_DIR/parent"
+    local dest_abs="$TEST_DIR/dest-project"
+    local old_encoded="${source_abs//\//-}"
+    local new_encoded="${dest_abs//\//-}"
+
+    mkdir -p "$MOCK_CLAUDE_DIR/projects/$new_encoded"
+    echo '{"type":"session","data":"new"}' > "$MOCK_CLAUDE_DIR/projects/$new_encoded/session2.jsonl"
+
+    "$SCRIPT" "$source_abs" "$dest_abs" -f
+
+    assert_not_exists "$MOCK_CLAUDE_DIR/projects/$new_encoded/$old_encoded" \
+        "Old history folder must not be nested inside the new one" || return 1
+    assert_exists "$MOCK_CLAUDE_DIR/projects/$new_encoded/session1.jsonl" \
+        "Old session should be merged into the existing folder" || return 1
+    assert_exists "$MOCK_CLAUDE_DIR/projects/$new_encoded/session2.jsonl" \
+        "Existing session should be preserved" || return 1
+    assert_not_exists "$MOCK_CLAUDE_DIR/projects/$old_encoded" \
+        "Old history folder should be gone after the merge" || return 1
+}
+
+test_fix_merges_existing_history_folder() {
+    # Manual mv already happened and claude was opened at the new location,
+    # so both old and new history folders exist (main and nested)
+    local old_abs="$TEST_DIR/old-location"
+    local new_abs="$TEST_DIR/new-location"
+    mkdir -p "$new_abs/webapp"
+
+    local old_encoded="${old_abs//\//-}"
+    local new_encoded="${new_abs//\//-}"
+    create_mock_history_folder "$old_encoded" "$old_abs"
+    create_mock_history_folder "${old_encoded}-webapp" "$old_abs/webapp"
+
+    mkdir -p "$MOCK_CLAUDE_DIR/projects/$new_encoded"
+    echo '{"type":"session","data":"new"}' > "$MOCK_CLAUDE_DIR/projects/$new_encoded/session2.jsonl"
+    mkdir -p "$MOCK_CLAUDE_DIR/projects/${new_encoded}-webapp"
+    echo '{"type":"session","data":"new"}' > "$MOCK_CLAUDE_DIR/projects/${new_encoded}-webapp/session2.jsonl"
+
+    "$SCRIPT" --fix --from "$old_abs" --to "$new_abs" -f
+
+    assert_exists "$MOCK_CLAUDE_DIR/projects/$new_encoded/session1.jsonl" \
+        "Old session should be merged into the existing folder" || return 1
+    assert_exists "$MOCK_CLAUDE_DIR/projects/$new_encoded/session2.jsonl" \
+        "Existing session should be preserved" || return 1
+    assert_not_exists "$MOCK_CLAUDE_DIR/projects/$old_encoded" \
+        "Old history folder should be gone after the merge" || return 1
+    assert_exists "$MOCK_CLAUDE_DIR/projects/${new_encoded}-webapp/session1.jsonl" \
+        "Old nested session should be merged into the existing folder" || return 1
+    assert_not_exists "$MOCK_CLAUDE_DIR/projects/${old_encoded}-webapp" \
+        "Old nested history folder should be gone after the merge" || return 1
+}
+
 # ============================================================================
 # MAIN
 # ============================================================================
@@ -987,6 +1043,8 @@ main() {
         test_move_skips_lookalike_sibling
         test_move_nested_dry_run
         test_fix_nested_project_history
+        test_move_merges_existing_history_folder
+        test_fix_merges_existing_history_folder
     )
 
     # Run specific test or all tests

--- a/test.sh
+++ b/test.sh
@@ -925,6 +925,32 @@ test_fix_nested_project_history() {
         "Old nested path should not remain in history" || return 1
 }
 
+test_move_nested_multi_cwd_history() {
+    # Sessions resumed from different directories record several cwd values
+    # in one file. The first cwd can be outside the nested project (e.g. the
+    # parent root); the folder must still be recognized as nested.
+    create_mock_project "$TEST_DIR/parent"
+    local source_abs="$TEST_DIR/parent"
+    local dest_abs="$TEST_DIR/dest-project"
+
+    mkdir -p "$source_abs/webapp"
+    local child_encoded="${source_abs//\//-}-webapp"
+    mkdir -p "$MOCK_CLAUDE_DIR/projects/$child_encoded"
+    {
+        echo "{\"type\":\"session\",\"cwd\":\"$TEST_DIR\",\"data\":\"resumed elsewhere\"}"
+        echo "{\"type\":\"session\",\"cwd\":\"$source_abs/webapp\",\"data\":\"test\"}"
+    } > "$MOCK_CLAUDE_DIR/projects/$child_encoded/session1.jsonl"
+    echo "{\"project\":\"$source_abs/webapp\",\"session\":\"session1\"}" >> "$MOCK_CLAUDE_DIR/history.jsonl"
+
+    "$SCRIPT" "$source_abs" "$dest_abs" -f
+
+    local new_child_encoded="${dest_abs//\//-}-webapp"
+    assert_not_exists "$MOCK_CLAUDE_DIR/projects/$child_encoded" \
+        "Old nested history folder should be gone" || return 1
+    assert_dir_exists "$MOCK_CLAUDE_DIR/projects/$new_child_encoded" \
+        "Nested folder with mixed cwd values should still be migrated" || return 1
+}
+
 test_move_merges_existing_history_folder() {
     # Destination history folder already exists (claude was opened at the
     # new location before running clamp). A plain mv would nest the old
@@ -1043,6 +1069,7 @@ main() {
         test_move_skips_lookalike_sibling
         test_move_nested_dry_run
         test_fix_nested_project_history
+        test_move_nested_multi_cwd_history
         test_move_merges_existing_history_folder
         test_fix_merges_existing_history_folder
     )


### PR DESCRIPTION
Fixes #13.

## The problem

After moving a project with clamp, `claude --resume` at the new location can come up empty even though the migration reported success. Two separate gaps in the move and fix operations cause old sessions to become invisible:

**1. Nested project histories are left behind.** Claude Code treats every working directory as its own project. If you ever ran sessions from a subdirectory of your project (or from a `.claude-worktrees` checkout), `~/.claude/projects/` holds several encoded folders for the same repository:

```
-home-user-Projects-my-project                    (sessions from the root)
-home-user-Projects-my-project-webapp             (sessions from my-project/webapp)
-home-user-Projects-my-project--claude-worktrees-feature-x
```

clamp only migrated the exact path it was given. The root folder was renamed and its `history.jsonl` entries updated, but the nested folders kept their old names and their entries kept pointing at the old path. `/resume` from the subdirectory found nothing, and `--fix` had the same blind spot, so there was no way to recover with clamp itself.

**2. An existing destination folder swallows the old one** (the failure reported in #13). If claude was opened at the new location before the migration, `~/.claude/projects/` already contains a folder with the new encoded name. The move then ran `mv old new`, and with `new` being an existing directory, the old folder landed *inside* it:

```
~/.claude/projects/-home-user-Projects-NewName/
  -home-user-Projects-OldName/      <- old sessions, one level too deep
    7d402b0d-....jsonl
```

`claude --resume` only scans the top level, so the moved sessions never appeared. `--fix` didn't help either: it skipped the rename with a warning whenever the destination existed, leaving the sessions stranded.

## The fix

**Nested histories:** the move and `--fix --from/--to` operations now find encoded folders that belong to projects nested inside the moved path and rename them along with the parent. `history.jsonl` updates gained a prefix rule (`"project":"/old/path/` becomes `"project":"/new/path/`) so entries for nested paths are rewritten too.

One subtlety: the encoded format is lossy, so a plain name prefix match would also catch siblings. Moving `my-project` must not touch `my-project-api`, even though `-home-user-my-project-api` starts with `-home-user-my-project-`. Candidates are confirmed against the `cwd` field that Claude Code records in every session file, with nested paths from `history.jsonl` as a fallback when a folder has no readable `cwd`. Folders that can't be confirmed are left alone.

**Existing destination:** when the destination history folder already exists, both operations now merge the old folder's contents into it instead of nesting (move) or giving up (fix). Session files are named by UUID so collisions are rare; anything that does collide stays at the destination and the original is left in place with a warning. The emptied source folder is removed.

All new renames and merges are tracked and reversed by the existing rollback trap, and the dry-run preview lists nested folders and announces merges.

## Tests

Seven new cases in `test.sh`, each written before its fix and failing without it:

- `test_move_nested_project_history`: nested folder renamed, history entry updated
- `test_move_nested_worktree_history`: `.claude-worktrees` folders (dot encoded as a dash) migrate too
- `test_move_skips_lookalike_sibling`: `parent-api` is untouched when moving `parent`
- `test_move_nested_dry_run`: preview lists nested folders and changes nothing
- `test_fix_nested_project_history`: `--fix --from --to` repairs nested folders after a manual `mv`
- `test_move_merges_existing_history_folder`: reproduces the #13 double-nesting, now merges instead
- `test_fix_merges_existing_history_folder`: `--fix` merges main and nested folders into existing destinations

Full suite: 39 passed, 1 skipped (case-insensitive filesystem test on Linux). The 3 `--list` failures also occur on unmodified `main` and are unrelated; they are addressed by the pending release pipeline PR. ShellCheck reports no new warnings, and the new code sticks to bash 3.2 constructs (no associative arrays).
